### PR TITLE
Use GetState alias

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v3.0.0"
+github "Quick/Nimble" "v3.1.0"
 github "Quick/Quick" "v0.8.0"

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -17,7 +17,7 @@ import Foundation
 
  It is recommended that you define your own types that conform to `Action` - if you want to be able
  to serialize your custom action types, you can implement `StandardActionConvertible` which will
- make it possible to generate a `StanardAction` from your typed action - the best of both worlds!
+ make it possible to generate a `StandardAction` from your typed action - the best of both worlds!
 */
 public struct StandardAction: Action {
     /// A String that identifies the type of this `StandardAction`

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public typealias DispatchFunction =  (Action) -> Any
-public typealias GetState = () -> StateType
+public typealias GetState = () -> StateType?
 public typealias Middleware = (DispatchFunction, GetState) -> DispatchFunction -> DispatchFunction

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -10,4 +10,4 @@ import Foundation
 
 public typealias DispatchFunction =  (Action) -> Any
 public typealias GetState = () -> StateType?
-public typealias Middleware = (DispatchFunction, GetState) -> DispatchFunction -> DispatchFunction
+public typealias Middleware = (DispatchFunction?, GetState) -> DispatchFunction -> DispatchFunction

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -10,5 +10,4 @@ import Foundation
 
 public typealias DispatchFunction =  (Action) -> Any
 public typealias GetState = () -> StateType
-public typealias Middleware = (DispatchFunction, GetState)
-                                -> DispatchFunction -> DispatchFunction
+public typealias Middleware = (DispatchFunction, GetState) -> DispatchFunction -> DispatchFunction

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 public typealias DispatchFunction =  (Action) -> Any
-public typealias Middleware = (DispatchFunction, () -> StateType)
+public typealias GetState = () -> StateType
+public typealias Middleware = (DispatchFunction, GetState)
                                 -> DispatchFunction -> DispatchFunction

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -41,7 +41,7 @@ public class Store<State: StateType>: StoreType {
         // Wrap the dispatch function with all middlewares
         self.dispatchFunction = middleware.reverse().reduce(self._defaultDispatch) {
             dispatchFunction, middleware in
-            return middleware(self.dispatch, { self.state })(dispatchFunction)
+            return middleware(self.dispatch, self.getState)(dispatchFunction)
         }
 
         if let state = state {
@@ -132,4 +132,7 @@ public class Store<State: StateType>: StoreType {
     public typealias AsyncActionCreator = (state: State, store: Store,
         actionCreatorCallback: ActionCreator -> Void) -> Void
 
+    private func getState() -> State {
+        return state
+    }
 }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -40,8 +40,9 @@ public class Store<State: StateType>: StoreType {
 
         // Wrap the dispatch function with all middlewares
         self.dispatchFunction = middleware.reverse().reduce(self._defaultDispatch) {
-            dispatchFunction, middleware in
-            return middleware(self.dispatch, self.getState)(dispatchFunction)
+            [weak self] dispatchFunction, middleware in
+                let getState = { self?.state }
+                return middleware(self?.dispatch, getState)(dispatchFunction)
         }
 
         if let state = state {
@@ -131,8 +132,4 @@ public class Store<State: StateType>: StoreType {
 
     public typealias AsyncActionCreator = (state: State, store: Store,
         actionCreatorCallback: ActionCreator -> Void) -> Void
-
-    private func getState() -> State {
-        return state
-    }
 }

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -44,7 +44,7 @@ let dispatchingMiddleware: Middleware = { dispatch, getState in
         return { action in
 
             if var action = action as? SetValueAction {
-                dispatch(SetValueStringAction("\(action.value)"))
+                dispatch?(SetValueStringAction("\(action.value)"))
 
                 return "Converted Action Successfully"
             }
@@ -64,7 +64,7 @@ let stateAccessingMiddleware: Middleware = { dispatch, getState in
             // avoid endless recursion by checking if we've dispatched exactly this action
             if appState?.testValue == "OK" && stringAction?.value != "Not OK" {
                 // dispatch a new action
-                dispatch(SetValueStringAction("Not OK"))
+                dispatch?(SetValueStringAction("Not OK"))
 
                 // and swallow the current one
                 return next(StandardAction("No-Op-Action"))

--- a/SwiftFlow/CoreTypes/StoreType.swift
+++ b/SwiftFlow/CoreTypes/StoreType.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /**
 Defines the interface of Stores in Swift Flow. `MainStore` is the default implementation of this
-interaface. Applications have a single store that stores the entire application state.
+interface. Applications have a single store that stores the entire application state.
 Stores receive actions and use reducers combined with these actions, to calculate state changes.
 Upon every state update a store informs all of its subscribers.
 */


### PR DESCRIPTION
I think using alias `GetState` would make applying middlewares more readable :relieved: