### PR TITLE
Fix Counter Example missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This repository contains the core component for ReSwift, the following extension
 
 # Example Projects
 
-- [CounterExample](https://github.com/ReSwift/CounterExample): A very simple counter app implemented with ReSwift. This app also demonstrates the basics of routing with ReSwiftRouter.
+- [CounterExample](https://github.com/ReSwift/CounterExample-Navigation-TimeTravel): A very simple counter app implemented with ReSwift. This app also demonstrates the basics of routing with ReSwiftRouter.
 - [Meet](https://github.com/Ben-G/Meet): A real world application being built with ReSwift - currently still very early on.
 
 # Contributing


### PR DESCRIPTION
Shouldn't the counter example points to this https://github.com/ReSwift/CounterExample-Navigation-TimeTravel?