### PR TITLE
Allow Subscribers to Subselect a State

### DIFF
--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		250F94D31C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250F94D21C548B90001FAAC8 /* StoreSubscriberSpec.swift */; };
+		250F94D41C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250F94D21C548B90001FAAC8 /* StoreSubscriberSpec.swift */; };
+		250F94D51C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250F94D21C548B90001FAAC8 /* StoreSubscriberSpec.swift */; };
 		252982EE1C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
 		252982EF1C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
 		252982F01C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
@@ -102,6 +105,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		250F94D21C548B90001FAAC8 /* StoreSubscriberSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSubscriberSpec.swift; sourceTree = "<group>"; };
 		252982ED1C4FD21400281098 /* StoreType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreType.swift; sourceTree = "<group>"; };
 		259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreMiddlewareTests.swift; sourceTree = "<group>"; };
 		259737FA1C2C618A00869B8F /* TestFakes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFakes.swift; sourceTree = "<group>"; };
@@ -252,6 +256,7 @@
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
 				625AA6311C33AFA600FEB431 /* ActionSpec.swift */,
+				250F94D21C548B90001FAAC8 /* StoreSubscriberSpec.swift */,
 				621C06181C276A5A008029AE /* Frameworks iOS */,
 				73C85BC41C30E5D600EABD08 /* Frameworks OSX */,
 				73C85BC91C30E5ED00EABD08 /* Frameworks tvOS */,
@@ -675,6 +680,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
+				250F94D51C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */,
 				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				625AA6351C33AFB800FEB431 /* ActionSpec.swift in Sources */,
 				25DBCF731C30C34000D63A58 /* CombinedReducerTests.swift in Sources */,
@@ -705,6 +711,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
+				250F94D41C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */,
 				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				625AA6341C33AFB700FEB431 /* ActionSpec.swift in Sources */,
 				25DBCF9E1C30C50000D63A58 /* CombinedReducerTests.swift in Sources */,
@@ -735,6 +742,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */,
+				250F94D31C548B90001FAAC8 /* StoreSubscriberSpec.swift in Sources */,
 				259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */,
 				625AA6331C33AFB600FEB431 /* ActionSpec.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -21,7 +21,10 @@ public class Store<State: StateType>: StoreType {
 
     /*private (set)*/ public var state: State! {
         didSet {
-            subscribers.forEach { $0._newState(state) }
+            subscribers.forEach {
+                let newState = $0._selectSubstate(state)
+                $0._newState(newState)
+            }
         }
     }
 

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -9,19 +9,34 @@
 import Foundation
 
 public protocol AnyStoreSubscriber: class {
-    func _newState(state: StateType)
+    func _newState(state: Any)
+    func _selectSubstate(state: StateType) -> Any
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {
     typealias StoreSubscriberStateType
+    typealias AppSpecificState
 
     func newState(state: StoreSubscriberStateType)
+    func selectSubstate(state: AppSpecificState) -> StoreSubscriberStateType
 }
 
 extension StoreSubscriber {
-    public func _newState(state: StateType) {
+    public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
             newState(typedState)
         }
+    }
+
+    public func _selectSubstate(state: StateType) -> Any {
+        if let typedState = state as? AppSpecificState {
+            return selectSubstate(typedState)
+        } else {
+            return state
+        }
+    }
+
+    public func selectSubstate(state: StoreSubscriberStateType) -> StoreSubscriberStateType {
+        return state
     }
 }

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -31,9 +31,9 @@ extension StoreSubscriber {
     public func _selectSubstate(state: StateType) -> Any {
         if let typedState = state as? AppSpecificState {
             return selectSubstate(typedState)
-        } else {
-            return state
         }
+
+        return state
     }
 
     public func selectSubstate(state: StoreSubscriberStateType) -> StoreSubscriberStateType {

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -1,0 +1,55 @@
+//
+//  StoreSubscriberSpec.swift
+//  ReSwift
+//
+//  Created by Benji Encz on 1/23/16.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+import XCTest
+import Quick
+import Nimble
+@testable import ReSwift
+
+// swiftlint:disable function_body_length
+class StoreSubsriberSpec: QuickSpec {
+
+    override func spec() {
+
+        var store: Store<TestAppState>!
+        var reducer: TestReducer!
+
+        describe("Substate Selection") {
+
+            beforeEach {
+                reducer = TestReducer()
+                store = Store(reducer: reducer, state: TestAppState())
+            }
+
+            it("it allows subscribers to subselect a state") {
+                let subscriber = TestSelectiveSubscriber()
+
+                store.subscribe(subscriber)
+                store.dispatch(SetValueAction(5))
+
+                expect(subscriber.receivedValue).to(equal(5))
+            }
+
+        }
+
+    }
+
+}
+
+class TestSelectiveSubscriber: StoreSubscriber {
+    var receivedValue: Int?
+
+    func newState(state: Int?) {
+        receivedValue = state
+    }
+
+    func selectSubstate(state: TestAppState) -> Int? {
+        return state.testValue
+    }
+
+}

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -51,6 +51,17 @@ class StoreSubsriberSpec: QuickSpec {
                 expect(subscriber.receivedValue?.age).to(equal(99))
             }
 
+            it("doesn't use the subselect if it's incorrect") {
+                let subscriber = TestIncorrectSelectiveSubscriber()
+
+                store.subscribe(subscriber)
+                store.dispatch(SetOtherStateAction(
+                    otherState: OtherState(name: "TestName", age: 99)
+                ))
+
+                expect(subscriber.receivedValue.0).to(beNil())
+                expect(subscriber.receivedValue.1).to(beNil())
+            }
         }
 
     }
@@ -122,6 +133,25 @@ class TestSelectiveSubscriberProtocol: StoreSubscriber {
 
     func newState(state: ContainsOtherState) {
         receivedValue = state.otherState
+    }
+
+}
+
+// MARK: Test Types for Incorrect type in Select Substate
+
+class TestIncorrectSelectiveSubscriber: StoreSubscriber {
+    var receivedValue: (Int?, String?)
+
+    // NOTE: the state argument is purposefully false here
+    func selectSubstate(state: String) -> (Int?, String?) {
+        return (
+            0,
+            ""
+        )
+    }
+
+    func newState(state: (Int?, String?)) {
+        receivedValue = state
     }
 
 }

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -93,7 +93,7 @@ struct TestValueStringReducer: Reducer {
     }
 }
 
-class TestStoreSubscriber<T>: StoreSubscriber {
+class TestStoreSubscriber<T: StateType>: StoreSubscriber {
     var receivedStates: [T] = []
 
     func newState(state: T) {
@@ -114,5 +114,9 @@ class DispatchingSubscriber: StoreSubscriber {
         if state.testValue != 5 {
             self.store.dispatch(SetValueAction(5))
         }
+    }
+
+    func selectSubstate(state: TestAppState) -> TestAppState {
+        return state
     }
 }


### PR DESCRIPTION
We have been discussing this in #43 and I think I'm pretty excited about this solution. This PR adds a method called `selectSubstate` to `StoreSubscriber`. 

The method comes with a default implementation, so it doesn't have to be implemented. You can implement it to subselect the state you are interested in. This solves the problem of always having acess to the global app state within a subscriber.

With a glance at `selectSubstate` you will be able to see which part of the state is flowing into a subscriber. I think it's about as declarative as it can get. Here's an example from the tests of what a selecting subscriber would look like:

```
class TestSelectiveSubscriber: StoreSubscriber {
    var receivedValue: (Int?, String?)

    func selectSubstate(state: TestComplexAppState) -> (Int?, String?) {
        return (
            state.testValue,
            state.otherState?.name
        )
    }

    func newState(state: (Int?, String?)) {
        receivedValue = state
    }

}
```

The input is the app state, the return type can be `Any` type, as long as it matches the argument of `newState`.

Waiting for some feedback. If we like this, I'll add some comments and then we can merge :ship:.