### PR TITLE
Substate Selection via Closure upon Subscription

### DIFF
--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
 		259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FA1C2C618A00869B8F /* TestFakes.swift */; };
 		259737FD1C2C661100869B8F /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FC1C2C661100869B8F /* Middleware.swift */; };
+		25AB3B811C54A84500A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
+		25AB3B821C54A84600A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
+		25AB3B831C54A84700A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
 		25DBCF3F1C30C16000D63A58 /* CombinedReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* CombinedReducer.swift */; };
 		25DBCF401C30C16000D63A58 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B61C1FFC880027C288 /* Action.swift */; };
 		25DBCF411C30C16000D63A58 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B71C1FFC880027C288 /* Store.swift */; };
@@ -106,6 +109,7 @@
 		259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreMiddlewareTests.swift; sourceTree = "<group>"; };
 		259737FA1C2C618A00869B8F /* TestFakes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFakes.swift; sourceTree = "<group>"; };
 		259737FC1C2C661100869B8F /* Middleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Middleware.swift; sourceTree = "<group>"; };
+		25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSubscriberSpec.swift; sourceTree = "<group>"; };
 		25DBCF371C30BF2B00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -252,6 +256,7 @@
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
 				625AA6311C33AFA600FEB431 /* ActionSpec.swift */,
+				25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */,
 				621C06181C276A5A008029AE /* Frameworks iOS */,
 				73C85BC41C30E5D600EABD08 /* Frameworks OSX */,
 				73C85BC91C30E5ED00EABD08 /* Frameworks tvOS */,
@@ -675,6 +680,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
+				25AB3B831C54A84700A41513 /* StoreSubscriberSpec.swift in Sources */,
 				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				625AA6351C33AFB800FEB431 /* ActionSpec.swift in Sources */,
 				25DBCF731C30C34000D63A58 /* CombinedReducerTests.swift in Sources */,
@@ -705,6 +711,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
+				25AB3B821C54A84600A41513 /* StoreSubscriberSpec.swift in Sources */,
 				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				625AA6341C33AFB700FEB431 /* ActionSpec.swift in Sources */,
 				25DBCF9E1C30C50000D63A58 /* CombinedReducerTests.swift in Sources */,
@@ -735,6 +742,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */,
+				25AB3B811C54A84500A41513 /* StoreSubscriberSpec.swift in Sources */,
 				259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */,
 				625AA6331C33AFB600FEB431 /* ActionSpec.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -33,7 +33,7 @@ public class Store<State: StateType>: StoreType {
 
     private var reducer: AnyReducer
 
-    var subscribers: [(subscriber: AnyStoreSubscriber, selector:(State -> Any)?)] = []
+    var subscribers: [(subscriber: AnyStoreSubscriber, selector: (State -> Any)?)] = []
 
     private var isDispatching = false
 
@@ -58,12 +58,18 @@ public class Store<State: StateType>: StoreType {
         }
     }
 
+    private func _isNewSubscriber(subscriber: AnyStoreSubscriber) -> Bool {
+        if subscribers.contains({ $0.subscriber === subscriber }) {
+            print("Store subscriber is already added, ignoring.")
+            return false
+        }
+
+        return true
+    }
+
     public func subscribe<S: StoreSubscriber
         where S.StoreSubscriberStateType == State>(subscriber: S) {
-            if subscribers.contains({ $0.0 === subscriber }) {
-                print("Store subscriber is already added, ignoring.")
-                return
-            }
+            if !_isNewSubscriber(subscriber) { return }
 
             subscribers.append((subscriber, nil))
 
@@ -75,6 +81,8 @@ public class Store<State: StateType>: StoreType {
     public func subscribe<SelectedState, S: StoreSubscriber
         where S.StoreSubscriberStateType == SelectedState>
         (subscriber: S, selector: (State -> SelectedState)) {
+            if !_isNewSubscriber(subscriber) { return }
+
             subscribers.append((subscriber, selector))
 
             if let state = self.state {
@@ -83,7 +91,7 @@ public class Store<State: StateType>: StoreType {
     }
 
     public func unsubscribe(subscriber: AnyStoreSubscriber) {
-        if let index = subscribers.indexOf({ return $0.0 === subscriber }) {
+        if let index = subscribers.indexOf({ return $0.subscriber === subscriber }) {
             subscribers.removeAtIndex(index)
         }
     }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -22,7 +22,9 @@ public class Store<State: StateType>: StoreType {
     /*private (set)*/ public var state: State! {
         didSet {
             subscribers.forEach {
-                $0.0._newState($0.1?(state) ?? state)
+                // if a selector is available, subselect the relevant state
+                // otherwise pass the entire state to the subscriber
+                $0.subscriber._newState($0.selector?(state) ?? state)
             }
         }
     }
@@ -31,7 +33,7 @@ public class Store<State: StateType>: StoreType {
 
     private var reducer: AnyReducer
 
-    var subscribers: [(AnyStoreSubscriber, (State -> Any)?)] = []
+    var subscribers: [(subscriber: AnyStoreSubscriber, selector:(State -> Any)?)] = []
 
     private var isDispatching = false
 

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol AnyStoreSubscriber: class {
-    func _newState(state: StateType)
+    func _newState(state: Any)
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {
@@ -19,7 +19,7 @@ public protocol StoreSubscriber: AnyStoreSubscriber {
 }
 
 extension StoreSubscriber {
-    public func _newState(state: StateType) {
+    public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
             newState(typedState)
         }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -41,7 +41,7 @@ public protocol StoreType {
 
      - parameter subscriber: Subscriber that will receive store updates
      */
-    func subscribe(subscriber: AnyStoreSubscriber)
+    func subscribe<S: StoreSubscriber where S.StoreSubscriberStateType == State>(subscriber: S)
 
     /**
      Unsubscribes the provided subscriber. The subscriber will no longer

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -17,16 +17,9 @@ class FilteredStoreSpec: QuickSpec {
 
         describe("#subscribe") {
 
-            var store: Store<TestAppState>!
-            var reducer: TestReducer!
-
-            beforeEach {
-                reducer = TestReducer()
-                store = Store(reducer: reducer, state: TestAppState())
-            }
-
-            it("dispatches initial value upon subscription") {
-                store = Store(reducer: reducer, state: TestAppState())
+            it("allows to pass a state selector closure") {
+                let reducer = TestReducer()
+                let store = Store(reducer: reducer, state: TestAppState())
                 let subscriber = TestFilteredSubscriber()
 
                 store.subscribe(subscriber) {
@@ -36,6 +29,27 @@ class FilteredStoreSpec: QuickSpec {
                 store.dispatch(SetValueAction(3))
 
                 expect(subscriber.receivedValue).to(equal(3))
+            }
+
+            it("supports complex state selector closures") {
+                let reducer = TestComplexAppStateReducer()
+                let store = Store(reducer: reducer, state: TestComplexAppState())
+                let subscriber = TestSelectiveSubscriber()
+
+                store.subscribe(subscriber) {
+                    (
+                        $0.testValue,
+                        $0.otherState?.name
+                    )
+                }
+
+                store.dispatch(SetValueAction(5))
+                store.dispatch(SetOtherStateAction(
+                    otherState: OtherState(name: "TestName", age: 99)
+                ))
+
+                expect(subscriber.receivedValue.0).to(equal(5))
+                expect(subscriber.receivedValue.1).to(equal("TestName"))
             }
         }
 
@@ -50,4 +64,48 @@ class TestFilteredSubscriber: StoreSubscriber {
         receivedValue = state
     }
 
+}
+
+/**
+ Example of how you can select a substate. The return value from
+ `selectSubstate` and the argument for `newState` need to match up.
+ */
+class TestSelectiveSubscriber: StoreSubscriber {
+    var receivedValue: (Int?, String?)
+
+    func newState(state: (Int?, String?)) {
+        receivedValue = state
+    }
+}
+
+struct TestComplexAppState: StateType {
+    var testValue: Int?
+    var otherState: OtherState?
+}
+
+struct OtherState {
+    var name: String?
+    var age: Int?
+}
+
+struct TestComplexAppStateReducer: Reducer {
+    func handleAction(action: Action, state: TestComplexAppState?) -> TestComplexAppState {
+        var state = state ?? TestComplexAppState()
+
+        switch action {
+        case let action as SetValueAction:
+            state.testValue = action.value
+            return state
+        case let action as SetOtherStateAction:
+            state.otherState = action.otherState
+        default:
+            break
+        }
+
+        return state
+    }
+}
+
+struct SetOtherStateAction: Action {
+    var otherState: OtherState
 }

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -1,0 +1,53 @@
+//
+//  StoreSubscriberSpec.swift
+//  ReSwift
+//
+//  Created by Benji Encz on 1/23/16.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import ReSwift
+
+// swiftlint:disable function_body_length
+class FilteredStoreSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("#subscribe") {
+
+            var store: Store<TestAppState>!
+            var reducer: TestReducer!
+
+            beforeEach {
+                reducer = TestReducer()
+                store = Store(reducer: reducer, state: TestAppState())
+            }
+
+            it("dispatches initial value upon subscription") {
+                store = Store(reducer: reducer, state: TestAppState())
+                let subscriber = TestFilteredSubscriber()
+
+                store.subscribe(subscriber) {
+                    $0.testValue
+                }
+
+                store.dispatch(SetValueAction(3))
+
+                expect(subscriber.receivedValue).to(equal(3))
+            }
+        }
+
+    }
+
+}
+
+class TestFilteredSubscriber: StoreSubscriber {
+    var receivedValue: Int?
+
+    func newState(state: Int?) {
+        receivedValue = state
+    }
+
+}

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -98,6 +98,16 @@ class StoreSpecs: QuickSpec {
                 expect(store.subscribers.count).to(equal(1))
             }
 
+            it("ignores identical subscribers that provide substate selectors") {
+                store = Store(reducer: reducer, state: TestAppState())
+                let subscriber = TestStoreSubscriber<TestAppState>()
+
+                store.subscribe(subscriber) { $0 }
+                store.subscribe(subscriber) { $0 }
+
+                expect(store.subscribers.count).to(equal(1))
+            }
+
         }
 
         describe("#dispatch") {


### PR DESCRIPTION
:fire: :fire:  #60 :fire: :fire:

Here comes a much more elegant solution. Thanks for @agentk for pushing me in this direction.
You now can optionally provide a closure upon subscription to build a subtree of the state you're interested in:

                store.subscribe(subscriber) {
                    (
                        $0.testValue,
                        $0.otherState?.name
                    )
                }

As an additional bonus, this PR introduces generic constraints on `Subscriber` so that the compiler will now complain if the subscriber is not listening to the `State` type of the store (when no closure is provided) or when the return type of the selector does not match the type the `Subscriber` is interested in.