### PR TITLE
Conceptualize Subscriptions

### DIFF
--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -95,7 +95,7 @@ class StoreSpecs: QuickSpec {
                 store.subscribe(subscriber)
                 store.subscribe(subscriber)
 
-                expect(store.subscribers.count).to(equal(1))
+                expect(store.subscriptions.count).to(equal(1))
             }
 
             it("ignores identical subscribers that provide substate selectors") {
@@ -105,7 +105,7 @@ class StoreSpecs: QuickSpec {
                 store.subscribe(subscriber) { $0 }
                 store.subscribe(subscriber) { $0 }
 
-                expect(store.subscribers.count).to(equal(1))
+                expect(store.subscriptions.count).to(equal(1))
             }
 
         }


### PR DESCRIPTION
The `Store.subscribers` array was extended as discussed in #60 to include a substate selector. The resulting tuple is not a subscriber itself anymore but rather a subscription. The `typealias` opens up ways to extend this even further with a `struct` replacement later.