### PR TITLE
Store now keeps a weak reference to subscribers

### DIFF
--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 		73C85BC81C30E5E900EABD08 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BC61C30E5E900EABD08 /* Quick.framework */; };
 		73C85BCC1C30E5FC00EABD08 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BCA1C30E5FC00EABD08 /* Nimble.framework */; };
 		73C85BCD1C30E5FC00EABD08 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BCB1C30E5FC00EABD08 /* Quick.framework */; };
+		81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
+		81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
+		81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
+		81BCBED11C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,6 +142,7 @@
 		73C85BC61C30E5E900EABD08 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		73C85BCA1C30E5FC00EABD08 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		73C85BCB1C30E5FC00EABD08 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
+		81BCBECD1C63167A00AA4F03 /* Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -284,6 +289,7 @@
 				625E66B91C1FFC880027C288 /* State.swift */,
 				625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */,
 				252982ED1C4FD21400281098 /* StoreType.swift */,
+				81BCBECD1C63167A00AA4F03 /* Subscription.swift */,
 			);
 			path = CoreTypes;
 			sourceTree = "<group>";
@@ -651,6 +657,7 @@
 				25DBCF421C30C16000D63A58 /* Reducer.swift in Sources */,
 				25DBCF431C30C16000D63A58 /* State.swift in Sources */,
 				252982F11C4FD21400281098 /* StoreType.swift in Sources */,
+				81BCBED11C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF451C30C16000D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF461C30C16000D63A58 /* Middleware.swift in Sources */,
 				25DBCF471C30C16000D63A58 /* Coding.swift in Sources */,
@@ -668,6 +675,7 @@
 				25DBCF591C30C19500D63A58 /* Reducer.swift in Sources */,
 				25DBCF5A1C30C19500D63A58 /* State.swift in Sources */,
 				252982F01C4FD21400281098 /* StoreType.swift in Sources */,
+				81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF5C1C30C19500D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF5D1C30C19500D63A58 /* Middleware.swift in Sources */,
 				25DBCF5E1C30C19500D63A58 /* Coding.swift in Sources */,
@@ -699,6 +707,7 @@
 				25DBCF951C30C4F000D63A58 /* Reducer.swift in Sources */,
 				25DBCF961C30C4F000D63A58 /* State.swift in Sources */,
 				252982EF1C4FD21400281098 /* StoreType.swift in Sources */,
+				81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF981C30C4F000D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF991C30C4F000D63A58 /* Middleware.swift in Sources */,
 				25DBCF9A1C30C4F000D63A58 /* Coding.swift in Sources */,
@@ -730,6 +739,7 @@
 				625E66BC1C1FFC880027C288 /* Action.swift in Sources */,
 				259737FD1C2C661100869B8F /* Middleware.swift in Sources */,
 				252982EE1C4FD21400281098 /* StoreType.swift in Sources */,
+				81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				625E66BE1C1FFC880027C288 /* Reducer.swift in Sources */,
 				625E66B41C1FFC830027C288 /* TypeHelper.swift in Sources */,
 				625E67061C20032E0027C288 /* CombinedReducer.swift in Sources */,

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -23,6 +23,7 @@ public class Store<State: StateType>: StoreType {
 
     /*private (set)*/ public var state: State! {
         didSet {
+            subscriptions = subscriptions.filter { $0.subscriber != nil }
             subscriptions.forEach {
                 // if a selector is available, subselect the relevant state
                 // otherwise pass the entire state to the subscriber

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -72,24 +72,18 @@ public class Store<State: StateType>: StoreType {
 
     public func subscribe<S: StoreSubscriber
         where S.StoreSubscriberStateType == State>(subscriber: S) {
-            if !_isNewSubscriber(subscriber) { return }
-
-            subscriptions.append(Subscription(subscriber: subscriber, selector: nil))
-
-            if let state = self.state {
-                subscriber._newState(state)
-            }
+            subscribe(subscriber, selector: nil)
     }
 
     public func subscribe<SelectedState, S: StoreSubscriber
         where S.StoreSubscriberStateType == SelectedState>
-        (subscriber: S, selector: (State -> SelectedState)) {
+        (subscriber: S, selector: (State -> SelectedState)?) {
             if !_isNewSubscriber(subscriber) { return }
 
             subscriptions.append(Subscription(subscriber: subscriber, selector: selector))
 
             if let state = self.state {
-                subscriber._newState(selector(state))
+                subscriber._newState(selector?(state) ?? state)
             }
     }
 

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -1,0 +1,14 @@
+//
+//  SubscriberWrapper.swift
+//  ReSwift
+//
+//  Created by Virgilio Favero Neto on 4/02/2016.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+import Foundation
+
+struct Subscription<State: StateType> {
+    private(set) weak var subscriber: AnyStoreSubscriber? = nil
+    let selector: (State -> Any)?
+}

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -50,6 +50,28 @@ class StoreSpecs: QuickSpec {
                 expect(store.subscriptions.flatMap({ $0.subscriber })).to(beEmpty())
             }
 
+            it("removes deferenced subscribers before notifying state changes") {
+                store = Store(reducer: reducer, state: TestAppState())
+                var subscriber1: TestSubscriber? = TestSubscriber()
+                var subscriber2: TestSubscriber? = TestSubscriber()
+
+                store.subscribe(subscriber1!)
+                store.subscribe(subscriber2!)
+                store.dispatch(SetValueAction(3))
+                expect(store.subscriptions.count).to(equal(2))
+                expect(subscriber1?.receivedStates.last?.testValue).to(equal(3))
+                expect(subscriber2?.receivedStates.last?.testValue).to(equal(3))
+
+                subscriber1 = nil
+                store.dispatch(SetValueAction(5))
+                expect(store.subscriptions.count).to(equal(1))
+                expect(subscriber2?.receivedStates.last?.testValue).to(equal(5))
+
+                subscriber2 = nil
+                store.dispatch(SetValueAction(8))
+                expect(store.subscriptions).to(beEmpty())
+            }
+
             it("dispatches initial value upon subscription") {
                 store = Store(reducer: reducer, state: TestAppState())
                 let subscriber = TestStoreSubscriber<TestAppState>()


### PR DESCRIPTION
Transformed the typealias `Subscription` into a `Struct` and added a weak reference to the `subscriber`.

Fixes https://github.com/ReSwift/ReSwift/issues/62