### PR TITLE
Fix Retain Cycle Caused by Store's Dispatch Method

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -48,10 +48,12 @@ public class Store<State: StateType>: StoreType {
         self.reducer = reducer
 
         // Wrap the dispatch function with all middlewares
-        self.dispatchFunction = middleware.reverse().reduce(_defaultDispatch) {
-            [weak self] dispatchFunction, middleware in
-            let getState = { self?.state }
-            return middleware(self?.dispatch, getState)(dispatchFunction)
+        self.dispatchFunction = middleware
+            .reverse()
+            .reduce({ [unowned self] action in self._defaultDispatch(action) }) {
+                [weak self] dispatchFunction, middleware in
+                    let getState = { self?.state }
+                    return middleware(self?.dispatch, getState)(dispatchFunction)
         }
 
         if let state = state {


### PR DESCRIPTION
Fixes retain cycle within Store: #66. Storing a reference to an instance method in an instance member leads to a retain cycle in Swift, so we need to use an explicit closure.

Within the closure it's important not to treat `self` as optional, otherwise the return type of the `dispatch` method gets turned into an optional as well.

Not the nicest code, but as of now I don't know of any alternatives. We can always revisit in future.

