### PR TITLE
Doc update, and initial action renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Your reducer needs to respond to these different action types, that can be done 
 ```swift
 struct CounterReducer: Reducer {
 
-    func handleAction(var state: AppState, action: Action) -> AppState {
+    func handleAction(action: Action, state: AppState?) -> AppState {
+        var state = state ?? AppState()
+
         switch action {
         case _ as CounterActionIncrease:
             state.counter += 1

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -110,4 +110,4 @@ public protocol Action { }
 
 /// Initial Action that is dispatched as soon as the store is created.
 /// Reducers respond to this action by configuring their intial state.
-public struct SwiftFlowInit: Action {}
+public struct ReSwiftInit: Action {}

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -59,7 +59,7 @@ public class Store<State: StateType>: StoreType {
         if let state = state {
             self.state = state
         } else {
-            dispatch(SwiftFlowInit())
+            dispatch(ReSwiftInit())
         }
     }
 

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -23,7 +23,7 @@ class StoreSpecs: QuickSpec {
                 let reducer = MockReducer()
                 let _ = Store<CounterState>(reducer: reducer, state: nil)
 
-                expect(reducer.calledWithAction[0] is SwiftFlowInit).to(beTrue())
+                expect(reducer.calledWithAction[0] is ReSwiftInit).to(beTrue())
             }
 
         }

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -38,8 +38,7 @@ class StoreSpecs: QuickSpec {
                     let _ = DeInitStore(
                         reducer: reducer,
                         state: TestAppState(),
-                        deInitAction: { deInitCount++ }
-                    )
+                        deInitAction: { deInitCount++ })
                 }
 
                 expect(deInitCount).to(equal(1))

--- a/Readme/Changelog.md
+++ b/Readme/Changelog.md
@@ -8,6 +8,10 @@
 
 - `SwiftFlowInit` action has been renamed to `ReSwiftInit` - @vfn
 
+**Other:**
+
+- Update Documentation. Sample reducer code was slightly outdated - @vfn
+
 ## [0.2.4](https://github.com/ReSwift/ReSwift/releases/tag/0.2.4)
 
 *Released: 01/23/2015*

--- a/Readme/Changelog.md
+++ b/Readme/Changelog.md
@@ -4,6 +4,10 @@
 
 > Unreleased changes in [`master`](https://github.com/ReSwift/ReSwift) scheduled to be integrated into the next release.
 
+**API Changes:**
+
+- `SwiftFlowInit` action has been renamed to `ReSwiftInit` - @vfn
+
 ## [0.2.4](https://github.com/ReSwift/ReSwift/releases/tag/0.2.4)
 
 *Released: 01/23/2015*


### PR DESCRIPTION
Two minor updates, one in the README file to update the handleAction function, and the second although quite small is a breaking change. It's the rename of SwiftFlowInit to ReSwiftInit