### PR TITLE
Fix small typo in Getting Started Guide

### DIFF
--- a/Readme/Getting Started Guide.md
+++ b/Readme/Getting Started Guide.md
@@ -124,7 +124,7 @@ struct DataMutationReducer: Reducer {
 
     func handleAction(state: HasDataState, action: Action) -> HasDataState {
         switch action {
-        case let action as IncrementAction:
+        case let action as CreateContactWithEmail:
             return createContact(state, email: action.email)
         case let action as CreateContactWithTwitterUser:
             return createContact(state, twitterUser: action.twitterUser)


### PR DESCRIPTION
Just a small typo in the Getting Started documentation.