### PR TITLE
Set CocoaPods documentation URL to GitHub pages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+#Upcoming Release
+
+**Other:**
+
+- Move all documentation source into `Docs`, except `Readme`, `Changelog` and `License`.
+- Replace duplicated documentation with an enhanced `generate_docs.sh` build script.
+- Set CocoaPods documentation URL - (#56) @agentk
+
 #0.2.5
 
 *Released: 02/20/2015*
@@ -18,7 +26,6 @@
 - We now have a [hosted documentation for ReSwift](http://reswift.github.io/ReSwift/master/) - @agentk
 - Refactored subscribers into a explicit `Subscription` typealias - @DivineDominion
 - Refactored `dispatch` for `AsyncActionCreator` to avoid duplicate code - @sendyhalim
-
 
 #0.2.4
 

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/ReSwift/ReSwift"
   s.license          = { :type => "MIT", :file => "LICENSE.md" }
   s.author           = { "Benjamin Encz" => "me@benjamin-encz.de" }
+  s.documentation_url = "http://reswift.github.io/ReSwift/"
   s.social_media_url = "http://twitter.com/benjaminencz"
   s.source           = { :git => "https://github.com/ReSwift/ReSwift.git", :tag => s.version.to_s }
   s.ios.deployment_target     = '8.0'


### PR DESCRIPTION
Closes #56 