### PR TITLE
Issue #65

### DIFF
--- a/ReSwift/CoreTypes/CombinedReducer.swift
+++ b/ReSwift/CoreTypes/CombinedReducer.swift
@@ -29,8 +29,8 @@ public struct CombinedReducer: AnyReducer {
         self.reducers = reducers
     }
 
-    public func _handleAction(action: Action, state: StateType?) -> StateType {
-        return reducers.reduce(state) { (currentState, reducer) -> StateType in
+    public func _handleAction(action: Action, state: StateType?) -> StateType? {
+        return reducers.reduce(state) { (currentState, reducer) -> StateType? in
             reducer._handleAction(action, state: currentState)
         }!
     }

--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -9,17 +9,17 @@
 import Foundation
 
 public protocol AnyReducer {
-    func _handleAction(action: Action, state: StateType?) -> StateType
+    func _handleAction(action: Action, state: StateType?) -> StateType?
 }
 
 public protocol Reducer: AnyReducer {
     typealias ReducerStateType
 
-    func handleAction(action: Action, state: ReducerStateType?) -> ReducerStateType
+    func handleAction(action: Action, state: ReducerStateType?) -> ReducerStateType?
 }
 
 extension Reducer {
-    public func _handleAction(action: Action, state: StateType?) -> StateType {
+    public func _handleAction(action: Action, state: StateType?) -> StateType? {
         return withSpecificTypes(action, state: state, function: handleAction)
     }
 }

--- a/ReSwift/Utils/TypeHelper.swift
+++ b/ReSwift/Utils/TypeHelper.swift
@@ -21,7 +21,7 @@ import Foundation
 func withSpecificTypes<SpecificStateType, Action>(
         action: Action,
         state genericStateType: StateType?,
-        @noescape function: (action: Action, state: SpecificStateType?) -> SpecificStateType
+        @noescape function: (action: Action, state: SpecificStateType?) -> SpecificStateType?
     ) -> StateType {
         guard let genericStateType = genericStateType else {
             return function(action: action, state: nil) as! StateType

--- a/ReSwiftTests/CombinedReducerTests.swift
+++ b/ReSwiftTests/CombinedReducerTests.swift
@@ -15,7 +15,7 @@ class MockReducer: Reducer {
 
     var calledWithAction: [Action] = []
 
-    func handleAction(action: Action, state: CounterState?) -> CounterState {
+    func handleAction(action: Action, state: CounterState?) -> CounterState? {
         calledWithAction.append(action)
 
         return state ?? CounterState()
@@ -24,7 +24,7 @@ class MockReducer: Reducer {
 }
 
 class IncreaseByOneReducer: Reducer {
-    func handleAction(action: Action, state: CounterState?) -> CounterState {
+    func handleAction(action: Action, state: CounterState?) -> CounterState? {
         var state = state ?? CounterState()
 
         state.count = state.count + 1
@@ -34,7 +34,7 @@ class IncreaseByOneReducer: Reducer {
 }
 
 class IncreaseByTwoReducer: Reducer {
-    func handleAction(action: Action, state: CounterState?) -> CounterState {
+    func handleAction(action: Action, state: CounterState?) -> CounterState? {
         var state = state ?? CounterState()
 
         state.count = state.count + 2

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -52,7 +52,7 @@ class FilteredStoreSpec: QuickSpec {
                 expect(subscriber.receivedValue.1).to(equal("TestName"))
             }
             
-             it("supports reducers that acces sub state via protocols") {
+             it("supports reducers that access sub state via protocols") {
             
                 let reducer = CombinedReducer([ TestComplexAppStateReducer(),TestHasOtherStateReducer()]);
                 let store = Store(reducer: reducer, state: TestComplexAppState())

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -37,7 +37,7 @@ class FilteredStoreSpec: QuickSpec {
                 let subscriber = TestSelectiveSubscriber()
 
                 store.subscribe(subscriber) {
-                   (
+                    (
                         $0.testValue,
                         $0.otherState?.name
                     )
@@ -51,10 +51,10 @@ class FilteredStoreSpec: QuickSpec {
                 expect(subscriber.receivedValue.0).to(equal(5))
                 expect(subscriber.receivedValue.1).to(equal("TestName"))
             }
-            
-             it("supports reducers that access sub state via protocols") {
-            
-                let reducer = CombinedReducer([ TestComplexAppStateReducer(),TestHasOtherStateReducer()]);
+
+            it("supports reducers that access sub state via protocols") {
+
+                let reducer = CombinedReducer([TestComplexAppStateReducer(), TestHasOtherStateReducer()])
                 let store = Store(reducer: reducer, state: TestComplexAppState())
                 let subscriber1 = TestSelectiveSubscriber()
                 let subscriber2 = TestOtherStateSubscriber()
@@ -64,9 +64,8 @@ class FilteredStoreSpec: QuickSpec {
                         $0.otherState?.name
                     )
                 }
-                 store.subscribe(subscriber2) {
+                store.subscribe(subscriber2) {
                     (
-                        
                         $0.otherState
                     )
                 }
@@ -78,17 +77,15 @@ class FilteredStoreSpec: QuickSpec {
 
                 expect(subscriber1.receivedValue.0).to(equal(5))
                 expect(subscriber1.receivedValue.1).to(equal("TestName"))
-                
+
                 store.dispatch(SetOtherStateAgeAction(age: 10))
-                store.dispatch(SetOtherStateNameAction(name: "Bloop"));
+                store.dispatch(SetOtherStateNameAction(name: "Bloop"))
 
                 expect(subscriber2.receivedValue?.age).to(equal(10))
                 expect(subscriber2.receivedValue?.name).to(equal("Bloop"))
             }
         }
-
     }
-
 }
 
 class TestFilteredSubscriber: StoreSubscriber {
@@ -97,7 +94,6 @@ class TestFilteredSubscriber: StoreSubscriber {
     func newState(state: Int?) {
         receivedValue = state
     }
-
 }
 
 /**
@@ -111,8 +107,9 @@ class TestSelectiveSubscriber: StoreSubscriber {
         receivedValue = state
     }
 }
+
 protocol HasOtherState {
-    var otherState:OtherState? {get set}
+    var otherState: OtherState? { get set }
 }
 
 struct OtherState {
@@ -120,11 +117,10 @@ struct OtherState {
     var age: Int?
 }
 
-struct TestComplexAppState: StateType,HasOtherState {
+struct TestComplexAppState: StateType, HasOtherState {
     var testValue: Int?
     var otherState: OtherState?
 }
-
 
 struct TestComplexAppStateReducer: Reducer {
     func handleAction(action: Action, state: TestComplexAppState?) -> TestComplexAppState? {
@@ -149,8 +145,8 @@ struct SetOtherStateAction: Action {
 }
 
 /*
-Test reducers that access substates through Has<SomeState> protocol
-*/
+ Test reducers that access substates through Has<SomeState> protocol
+ */
 class TestOtherStateSubscriber: StoreSubscriber {
     var receivedValue: OtherState?
 
@@ -159,12 +155,11 @@ class TestOtherStateSubscriber: StoreSubscriber {
     }
 }
 
-
 struct TestHasOtherStateReducer: Reducer {
     func handleAction(action: Action, state: HasOtherState?) -> HasOtherState? {
-      
-        if var state=state{
-            var otherState = state.otherState ?? OtherState();
+
+        if var state = state {
+            var otherState = state.otherState ?? OtherState()
 
             switch action {
             case let action as SetOtherStateNameAction:
@@ -172,15 +167,14 @@ struct TestHasOtherStateReducer: Reducer {
                 break
             case let action as SetOtherStateAgeAction:
                 otherState.age = action.age
-                 break
+                break
             default:
                 break
             }
-            state.otherState=otherState;
-            return state;
+            state.otherState = otherState
+            return state
         }
-        return state;
-       
+        return state
     }
 }
 
@@ -191,4 +185,3 @@ struct SetOtherStateNameAction: Action {
 struct SetOtherStateAgeAction: Action {
     var age: Int
 }
-

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -267,7 +267,7 @@ class DeInitStore<State: StateType>: Store<State> {
 class DispatchingReducer: Reducer {
     var store: Store<TestAppState>? = nil
 
-    func handleAction(action: Action, state: TestAppState?) -> TestAppState {
+    func handleAction(action: Action, state: TestAppState?) -> TestAppState? {
         expect(self.store?.dispatch(SetValueAction(20))).to(raiseException(named:
             "SwiftFlow:IllegalDispatchFromReducer"))
         return state ?? TestAppState()

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -66,7 +66,7 @@ struct SetValueStringAction: StandardActionConvertible {
 }
 
 struct TestReducer: Reducer {
-    func handleAction(action: Action, state: TestAppState?) -> TestAppState {
+    func handleAction(action: Action, state: TestAppState?) -> TestAppState? {
         var state = state ?? TestAppState()
 
         switch action {
@@ -80,7 +80,7 @@ struct TestReducer: Reducer {
 }
 
 struct TestValueStringReducer: Reducer {
-    func handleAction(action: Action, state: TestStringAppState?) -> TestStringAppState {
+    func handleAction(action: Action, state: TestStringAppState?) -> TestStringAppState? {
         var state = state ?? TestStringAppState()
 
         switch action {


### PR DESCRIPTION
This is a possible solution for issue #65.

By not requiring the reducer to hydrate the state, reducers can more easily use protocols to access slices of the app state that they are interested in.