### PR TITLE
Prepare Documentation for 1.0 Release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+#Contributing to ReSwift
+
+Some design decisions for the core of ReSwift are still up in the air (see [issues](https://github.com/ReSwift/ReSwift/issues)), there's lots of useful documentation that can be written and a ton of extensions and tools are waiting to be built on top of ReSwift.
+
+Pull requests are welcome on the [`master`](https://github.com/ReSwift/ReSwift) branch.
+
+We know making you first pull request can be scary. If you have trouble with any of the contribution rules, **still make the Pull Request**. We are here to help.
+
+We personally think the best way to get started contributing to this library is by using it in one of your projects!
+
+## Swift style guide
+
+We follow the [Ray Wenderlich Style Guide](https://github.com/raywenderlich/swift-style-guide) very closely with the following exception:
+
+- Use the Xcode default of 4 spaces for indentation.
+
+## SwiftLint
+
+[SwiftLint](https://github.com/realm/SwiftLint) runs automatically on all pull requests via [houndci.com](https://houndci.com/). If you have SwiftLint installed, you will receive the same warnings in Xcode at build time, that hound will check for on pull requests.
+
+Function body lengths in tests will often cause a SwiftLint warning. These can be handled on a per case bases by prefixing the function with:
+
+```swift
+// swiftlint:disable function_body_length
+func someFunctionThatShouldHaveAReallyLongBody() {}
+```
+
+Common violations to look out for are trailing white and valid docs.
+
+## Tests
+
+All code going into master requires testing. We keep code coverage at 100% to ensure the best possibility that all edge cases are tested for. It's good practice to test for any variations that can cause nil to be returned.
+
+Tests are run in [Travis CI](https://travis-ci.org/ReSwift/ReSwift) automatically on all pull requests, branches and tags. These are the same tests that run in Xcode at development time.
+
+## Comments
+
+- **Readable code should be preferred over commented code.**
+
+    Comments in code are used to document non-obvious use cases. For example, when the use of a piece of code looks unnecessary, and naming alone does not convey why it is required.
+
+- **Comments need to be updated or removed if the code changes.**
+
+    If a comment is included, it is just as important as code and has the same technical debt weight. The only thing worse than a unneeded comment is a comment that is not maintained.
+
+## Documentation
+
+Code documentation is different from comments. Please be liberal with code docs.
+
+When writing code docs, remember they are:
+
+- Displayed to a user in Xcode quick help
+- Used to generate API documentation
+- API documentation also generates Dash docsets
+
+In particular paying attention to:
+
+- Keeping docs current
+- Documenting all parameters and return types (SwiftLint helps with warning when they are not valid)
+- Stating common issues that a user may run into
+
+See [NSHipster Swift Documentation](http://nshipster.com/swift-documentation/) for a good reference on writing documentation in Swift.

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -15,7 +15,7 @@ The state struct should store your entire application state, that includes the U
 Here's an example of a state struct as defined in the [Counter Example](https://github.com/ReSwift/CounterExample):
 
 ```swift
-struct AppState: StateType, HasNavigationState {
+struct AppState: StateType {
     var counter: Int = 0
     var navigationState = NavigationState()
 }
@@ -23,55 +23,12 @@ struct AppState: StateType, HasNavigationState {
 
 There are multiple things to note:
 
-1. Your app state struct needs to conform to the `StateType` protocol, currently this is just a marker protocol, but we will likely add requirements (such as the ability to [serialize the state](https://github.com/ReSwift/ReSwift/issues/3)) before v1.0.
-2. If you are including `SwiftRouter` in your project, your app state needs to conform to the `HasNavigationState` protocol. This means you need to add a property called `navigationState` to your state struct. This is the sub-state the router will use to store the current route.
-
-## Viewing the State Through a Protocol
-
-Protocols are extremely useful for working with this library. As you can see in the example above, `SwiftRouter` can work with any app state that you define, as long as it conforms to the `HasNavigationState` protocol. The router will only ever access your app state through this protocol - this also means it won't ever see and depend upon any other state that you store within your state struct.
-
-**You should use this approach as much as possible in your app.** ReSwift provides some features that make this approach even easier to use. Let's say you want to expand the state above by a simple authentication state. You would do this by first defining a new struct for this sub-state:
-
-```swift
-struct AuthenticationState {
-    var userAuthenticated = false
-}
-```
-
-*Additionally,* you would define a protocol that requires your app state to include the `AuthenticationState`:
-
-```swift
-protocol HasAuthenticationState {
-    var authenticationState: AuthenticationState
-}
-```
-Now you can extend your state using this protocol:
-
-```swift
-struct AppState: StateType, HasNavigationState, HasAuthenticationState {
-    var counter: Int = 0
-    var navigationState = NavigationState()
-    var authenticationState = AuthenticationState()
-}
-```
-
-If you now add a view (or any other subscriber) that is only interested in this particular substate, you should express this within your `newState` method (that is the callback for all subscribers in ReSwift).
-
-You would implement the `newState` method as following:
-
-```swift
-    func newState(state: HasAuthenicationState) {
-        loggedInLabel.text = "\(state.authenticationState.userAuthenticated)"
-    }
-```
-ReSwift will infer the type that you have required and will automatically cast your app state to that type - this means the particular subscriber will only see the required substate, not any other state in your app. **This approach will help you reduce dependencies on state that should be irrelevant to your component**.
-
-Currently your method is not called if the state cannot be casted into the required type - [we're considering changing this into a `fatalError` as it will make debugging easier](https://github.com/ReSwift/ReSwift/issues/4).
+1. Your app state struct needs to conform to the `StateType` protocol, currently this is just a marker protocol.
+2. If you are including `ReSwiftRouter` in your project, your app state needs to contain a property of type `NavigationState`. This is the sub-state the router will use to store the current route.
 
 ## Derived State
 
 Note that you don't need to store derived state inside of your app state. E.g. instead of storing a `UIImage` you should store a image URL that can be used to fetch the image from a cache or via a download. The app state should store all the information that uniquely identifies the current state and allows it to be reconstructed, but none that can be easily derived.
-
 
 # Actions
 
@@ -79,7 +36,7 @@ Actions are used to express intended state changes. Actions don't contain functi
 
 In your ReSwift app you will define actions for every possible state change that can happen.
 
-Reducers handle these actions and implement state changes based on the information they provide.
+Reducers handle these actions and implement state changes based on the information the actions provide.
 
 All actions in ReSwift conform to the `Action` protocol, which currently is just a marker protocol.
 
@@ -117,44 +74,55 @@ Once ReSwift Recorder's implementation is further along, you will find detailed 
 
 # Reducers
 
-This is the only place where you should modify application state! Reducers, just as `StoreSubscribers` can define the particular slice of the app state that they are interested in by changing the type in their `handleAction` method. Here's an example of a part of a reducer in an app built with ReSwift:
+Reducers are the only place in which you should modify application state! Reducers take the current application state and an action and return the new transformed application state. We recommend to provide many small reducers that each handle a subset of your application state.
+
+You can do this implementing a top-level reducer that conforms to the `Reducer` protocol. This reducer will then call individual functions for each different part of the app state.
+
+Here's an example in which we construct a new state, by calling sub-reducers with different sub-states:
 
 ```swift
-struct DataMutationReducer: Reducer {
+struct AppReducer: Reducer {
 
-    func handleAction(state: HasDataState, action: Action) -> HasDataState {
-        switch action {
-        case let action as CreateContactWithEmail:
-            return createContact(state, email: action.email)
-        case let action as CreateContactWithTwitterUser:
-            return createContact(state, twitterUser: action.twitterUser)
-        case let action as DeleteContact:
-            return deleteContact(state, identifier: action.contactID)
-        case let action as SetContacts:
-            return setContacts(state, contacts: action.contacts)
-        default:
-            return state
-        }
+    func handleAction(action: Action, state: State?) -> State {
+        return State(
+            navigationState: NavigationReducer.handleAction(action, state: state?.navigationState),
+            authenticationState: authenticationReducer(state?.authenticationState, action: action),
+            repositories: repositoriesReducer(state?.repositories, action: action),
+            bookmarks: bookmarksReducer(state?.bookmarks, action: action)
+        )
     }
 
-    func createContact(var state: HasDataState, email: String) -> HasDataState {
-        let newContactID = state.dataState.contacts.count + 1
-        let newContact = Contact(identifier: newContactID, emailAddress: email)
-        state.dataState.contacts.append(newContact)
-
-        return state
-    }
-
-    func createContact(var state: HasDataState, twitterUser: TwitterUser) -> HasDataState {
-        let newContactID = state.dataState.contacts.count + 1
-        let newContact = Contact(identifier: newContactID, twitterHandle: twitterUser.username)
-        state.dataState.contacts.append(newContact)
-
-        return state
-    }
+}
 ```
+The `Reducer` protocol has a single method that takes an `Action` and an `State?` and returns a `State`. Typically reducers will be responsible for initializing the application state. When they receive `nil` as the current state, they should return the initial default value for their portion of the state. In the example above the `AppReducer` delegates all calls to other reducer functions. E.g. the `authenticationReducer` is responsible for providing the `authenticationState`.
 
-You typically switch over the types in `handleAction`, then call a method that implements the actual state mutation.
+Here's what the `authenticationReducer` function that is called from the `AppReducer` looks like:
+
+```swift
+func authenticationReducer(state: AuthenticationState?, action: Action) -> AuthenticationState {
+    var state = state ?? initialAuthenticationState()
+
+    switch action {
+    case _ as SwiftFlowInit:
+        break
+    case let action as SetOAuthURL:
+        state.oAuthURL = action.oAuthUrl
+    case let action as UpdateLoggedInState:
+        state.loggedInState = action.loggedInState
+    default:
+        break
+    }
+
+    return state
+}
+```
+You can see that the `authenticationReducer` function is a free function. You can define it with any arbitrary method signature, but we recommend that it matches the method in the `Reducer` protocol (current state and action in, new state out).
+
+This sub-reducer first checks if the state provided is `nil`. If that's the case, it sets the state to the initial default state. Next, the reducer switches over the provided `action` and checks its type. Depending on the type of action, this reducer will updated the state differently. This specific reducer is very simple, each action only triggers a single property of the state to update.
+
+Once the state update is complete, the reducer function returns the new state.
+
+After the `AppReducer` has called all of the sub-reducer functions, we have a new application state. `ReSwift` will take care of publishing this new state to all subscribers.
 
 # Store Subscribers
 
@@ -168,7 +136,56 @@ protocol StoreSubscriber {
 
 Most of your `StoreSubscriber`s will be in the view layer and update their representation whenever they receive a new state.
 
-# Middleware
+## Example With Filtered Subscriptions
+
+Ideally most of our subscribers should only be interested in a very small portion of the overall app state. `ReSwift` provides a way to subselect the relevant state for a particular subscriber at the point of subscription. Here's an example of subscribing, filtering and unsubscribing as used within a view controller:
+
+```
+override func viewWillAppear(animated: Bool) {
+    super.viewWillAppear(animated)
+
+	// subscribe when VC appears
+   	// we are only interested in repository substate, filter it out of the overall state
+    store.subscribe(self) { state in
+        state.repositories
+    }
+}
+
+override func viewWillDisappear(animated: Bool) {
+    super.viewWillDisappear(animated)
+    // unsubscribe when VC disappears
+    store.unsubscribe(self)
+}
+
+// The `state` argument needs to match the selected substate
+func newState(state: Response<[Repository]>?) {
+    if case let .Success(repositories) = state {
+        dataSource?.array = repositories
+        tableView.reloadData()
+    }
+}
+```
+In the example above we only select a single property from the overall application state: a network `Response` with a list of repositories.
+
+When selecting a substate as part of calling the `subscribe` method, you need to make sure that the argument of the `newState` method has the same type as whatever you return from the state subselection in the `subscribe` method.
+
+When subscribing within a ViewController you will typically update the view from within the `newState` method.
+
+#Beyond the Basics
+
+##Asynchronous Operations
+
+In order to handle state updates from asynchronous operations, such as network requests, `ReSwift` provides `ActionCreator` methods. 
+
+An `ActionCreator` has the following type signature:
+```swift
+typealias ActionCreator = (state: State, store: StoreType) -> Action?
+```
+An `ActionCreator` takes the current application state, and a reference to a store and might or might not return an `Action`. Just like `Action`s, `ActionCreator`s can be dispatched to the `Store`.
+
+We use `ActionCreator` in cases where the dispatching code does not now wether or not an action.
+
+## Middleware
 
 ReSwift supports middleware in the same way as Redux does, [you can read this great documentation on Redux middleware to get started](http://rackt.org/redux/docs/advanced/Middleware.html). Middleware allows developers to provide extensions that wrap the `dispatch` function.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2015 Benjamin Encz
+Copyright (c) 2016 ReSwift Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 [![Build Status](https://img.shields.io/travis/ReSwift/ReSwift/master.svg?style=flat-square)](https://travis-ci.org/ReSwift/ReSwift) [![Code coverage status](https://img.shields.io/codecov/c/github/ReSwift/ReSwift.svg?style=flat-square)](http://codecov.io/github/ReSwift/ReSwift) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ReSwift.svg?style=flat-square)](https://cocoapods.org/pods/ReSwift) [![Platform support](https://img.shields.io/badge/platform-ios%20%7C%20osx%20%7C%20tvos%20%7C%20watchos-lightgrey.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md)
 
-ReSwift is a [Redux](https://github.com/rackt/redux)-like implementation of the unidirectional data flow architecture in Swift. It embraces a unidirectional data flow that only allows state mutations through declarative actions.
+ReSwift is a [Redux](https://github.com/rackt/redux)-like implementation of the unidirectional data flow architecture in Swift. ReSwift helps you to separate three important concerns of your app's components:
+
+- **State**: in a ReSwift app the entire app state is explicitly stored in a data structure. This helps avoid complicated state management code, enables better debugging and has many, many more benefits...
+- **Views**: in a ReSwift app your views update when your state changes. Your views become simple visualizations of the current app state.
+- **State Changes**: in a ReSwift app you can only perform state changes through actions. Actions are small pieces of data that describe a state change. By drastically limiting the way state can be mutated, your app becomes easier to understand and it gets easier to work with many collaborators.
+
+The ReSwift library is tiny allowing users to dive into the code, understand every single line and [hopefully contribute](#contributing). 
+
+ReSwift is quickly growing beyond the core library, providing experimental extensions for routing and time traveling through past app states!
+
+Excited? So are we 🎉
 
 # Table of Contents
 
@@ -156,7 +166,9 @@ You can install ReSwift via [Carthage](https://github.com/Carthage/Carthage) by 
 
 # Checking out Source Code
 
-Due to an [issue in Nimble](https://github.com/Quick/Nimble/issues/213) at the moment, tvOS tests will fail if building Nimble / Quick from source. You can however install Nimble & Quick from binaries then rebuild OSX & iOS only. After checkout, run the following from the terminal:
+After cloning this repository you need to use carthage to install testing frameworks that ReSwift depends on.
+
+Due to an [issue in Nimble](https://github.com/Quick/Nimble/issues/213) at the moment, tvOS tests will fail if building Nimble / Quick from source. You can however install Nimble & Quick from binaries then rebuild OS X & iOS only. After checkout, run the following from the terminal:
 
 ```bash
 carthage bootstrap && carthage bootstrap --no-use-binaries --platform ios,osx

--- a/README.md
+++ b/README.md
@@ -2,19 +2,7 @@
 
 [![Build Status](https://img.shields.io/travis/ReSwift/ReSwift/master.svg?style=flat-square)](https://travis-ci.org/ReSwift/ReSwift) [![Code coverage status](https://img.shields.io/codecov/c/github/ReSwift/ReSwift.svg?style=flat-square)](http://codecov.io/github/ReSwift/ReSwift) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ReSwift.svg?style=flat-square)](https://cocoapods.org/pods/ReSwift) [![Platform support](https://img.shields.io/badge/platform-ios%20%7C%20osx%20%7C%20tvos%20%7C%20watchos-lightgrey.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md)
 
-# Intro
-
-**This library is a pre-release. Expect missing docs and breaking API changes.**
-
 ReSwift is a [Redux](https://github.com/rackt/redux)-like implementation of the unidirectional data flow architecture in Swift. It embraces a unidirectional data flow that only allows state mutations through declarative actions.
-
-### Merge announcement:
-
-**ReduxKit** and **Swift-Flow** have joined forces! The result is **ReSwift**.
-
-_The nitty gritty_: We decided to deprecate [ReduxKit](https://github.com/ReduxKit/ReduxKit) and keep it as a reference implementation of how an almost exact Redux implementation in Swift can be accomplished. It will no longer be actively maintained, but PRs are still welcome.
-
-Swift-Flow has adopted the name **ReSwift** and moved to it's new home as a nod to it's Redux roots that remain at it's core. Going forward, our combined efforts will be focused on ReSwift and surrounding tooling.
 
 # Table of Contents
 
@@ -188,70 +176,12 @@ This repository contains the core component for ReSwift, the following extension
 # Example Projects
 
 - [CounterExample](https://github.com/ReSwift/CounterExample-Navigation-TimeTravel): A very simple counter app implemented with ReSwift. This app also demonstrates the basics of routing with ReSwiftRouter.
-- [Meet](https://github.com/Ben-G/Meet): A real world application being built with ReSwift - currently still very early on.
+- [GitHubBrowserExample](https://github.com/ReSwift/GitHubBrowserExample): A real world example, involving authentication, network requests and navigation. Still WIP but should be the best resource for starting to adapt `ReSwift` in your own app.
+- [Meet](https://github.com/Ben-G/Meet): A real world application being built with ReSwift - currently still very early on. It is not up to date with the latest version of ReSwift, but is the best project for demonstrating time travel.
 
 # Contributing
 
-There's still a lot of work to do here! We would love to see you involved! Some design decisions for the core of ReSwift are still up in the air (see [issues](https://github.com/ReSwift/ReSwift/issues)), there's lots of useful documentation that can be written and a ton of extensions and tools are waiting to be built on top of ReSwift.
-
-Pull requests are welcome on the [`master`](https://github.com/ReSwift/ReSwift) branch.
-
-We know making you first pull request can be scary. If you have trouble with any of the contribution rules, **still make the Pull Request**. We are here to help.
-
-We personally think the best way to get started contributing to this library is by using it in one of your projects!
-
-## Swift style guide
-
-We follow the [Ray Wenderlich Style Guide](https://github.com/raywenderlich/swift-style-guide) very closely with the following exception:
-
-- Use the Xcode default of 4 spaces for indentation.
-
-## SwiftLint
-
-[SwiftLint](https://github.com/realm/SwiftLint) runs automatically on all pull requests via [houndci.com](https://houndci.com/). If you have SwiftLint installed, you will receive the same warnings in Xcode at build time, that hound will check for on pull requests.
-
-Function body lengths in tests will often cause a SwiftLint warning. These can be handled on a per case bases by prefixing the function with:
-
-```swift
-// swiftlint:disable function_body_length
-func someFunctionThatShouldHaveAReallyLongBody() {}
-```
-
-Common violations to look out for are trailing white and valid docs.
-
-## Tests
-
-All code going into master requires testing. We keep code coverage at 100% to ensure the best possibility that all edge cases are tested for. It's good practice to test for any variations that can cause nil to be returned.
-
-Tests are run in [Travis CI](https://travis-ci.org/ReSwift/ReSwift) automatically on all pull requests, branches and tags. These are the same tests that run in Xcode at development time.
-
-## Comments
-
-- **Readable code should be preferred over commented code.**
-
-    Comments in code are used to document non-obvious use cases. For example, when the use of a piece of code looks unnecessary, and naming alone does not convey why it is required.
-
-- **Comments need to be updated or removed if the code changes.**
-
-    If a comment is included, it is just as important as code and has the same technical debt weight. The only thing worse than a unneeded comment is a comment that is not maintained.
-
-## Documentation
-
-Code documentation is different from comments. Please be liberal with code docs.
-
-When writing code docs, remember they are:
-
-- Displayed to a user in Xcode quick help
-- Used to generate API documentation
-- API documentation also generates Dash docsets
-
-In particular paying attention to:
-
-- Keeping docs current
-- Documenting all parameters and return types (SwiftLint helps with warning when they are not valid)
-- Stating common issues that a user may run into
-
-See [NSHipster Swift Documentation](http://nshipster.com/swift-documentation/) for a good reference on writing documentation in Swift.
+There's still a lot of work to do here! We would love to see you involved! You can find all the details on how to get started in the [Contributing Guide](/CONTRIBUTING.md).
 
 # Credits
 
@@ -259,4 +189,8 @@ See [NSHipster Swift Documentation](http://nshipster.com/swift-documentation/) f
 
 # Get in touch
 
-If you have any questions, you can find me on twitter [@benjaminencz](https://twitter.com/benjaminencz).
+If you have any questions, you can find the core team on twitter:
+
+- [@benjaminencz](https://twitter.com/benjaminencz)
+- [@karlbowden](https://twitter.com/karlbowden)
+- [@ARendtslev](https://twitter.com/ARendtslev)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ ReSwift is a [Redux](https://github.com/rackt/redux)-like implementation of the 
 - [Getting Started Guide](#getting-started-guide)
 - [Installation](#installation)
 - [Testing](#testing)
+- [Checking Out Source Code](#checking-out-source-code)
 - [Demo](#demo)
 - [Extensions](#extensions)
 - [Example Projects](#example-projects)
+- [Contributing](#contributing)
 - [Credits](#credits)
 - [Get in touch](#get-in-touch)
 
@@ -129,7 +131,7 @@ The ReSwift tooling is still in a very early stage, but aforementioned prospects
 
 # Getting Started Guide
 
-[A Getting Started Guide that describes the core components of apps built with ReSwift lives here](http://reswift.github.io/ReSwift/master/getting-started-guide.html). It will be expanded in the next few weeks. To get an understanding of the core principles I recommend reading the brilliant [redux documentation](http://rackt.org/redux/).
+[A Getting Started Guide that describes the core components of apps built with ReSwift lives here](http://reswift.github.io/ReSwift/master/getting-started-guide.html). It will be expanded in the next few weeks. To get an understanding of the core principles we recommend reading the brilliant [redux documentation](http://rackt.org/redux/).
 
 # Installation
 
@@ -152,7 +154,7 @@ You can install ReSwift via [Carthage](https://github.com/Carthage/Carthage) by 
 
     github "ReSwift/ReSwift"
 
-# Checking out Source Code and Running Tests
+# Checking out Source Code
 
 Due to an [issue in Nimble](https://github.com/Quick/Nimble/issues/213) at the moment, tvOS tests will fail if building Nimble / Quick from source. You can however install Nimble & Quick from binaries then rebuild OSX & iOS only. After checkout, run the following from the terminal:
 


### PR DESCRIPTION
- **Move Contribution Details to a Separate File**: Visually it felt a little heavy frontloading details about code style, etc. I'm sure we'll see more contribution guidelines in future so it would be good to have a separate file
- **Update & Extend Getting Started Guide**: The Getting Started Guide is now up to date with the latest API changes and discusses some concepts it did not discuss before
- **Main Readme**: Remove merge announcement, add Karl's & Alex's twitter handle and change the preamble of the readme. I tried providing a motivating introduction before the TOC that describes benefits of ReSwift in simple, understandable terms.

@agentk I know that these changes will require recompiling & pushing the docs so I wanted to coordinate this with you. 