### PR TITLE
[Store] Remove Callbacks for Synchronous Dispatch

### DIFF
--- a/ReSwift/CoreTypes/CombinedReducer.swift
+++ b/ReSwift/CoreTypes/CombinedReducer.swift
@@ -1,6 +1,6 @@
 //
 //  MainReducer.swift
-//  Meet
+//  ReSwift
 //
 //  Created by Benjamin Encz on 11/11/15.
 //  Copyright © 2015 DigiTales. All rights reserved.

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -1,6 +1,6 @@
 //
 //  MainStore.swift
-//  SwiftFlow
+//  ReSwift
 //
 //  Created by Benjamin Encz on 11/11/15.
 //  Copyright © 2015 DigiTales. All rights reserved.
@@ -112,37 +112,33 @@ public class Store<State: StateType>: StoreType {
     }
 
     public func dispatch(action: Action) -> Any {
-        return dispatch(action, callback: nil)
+        let returnValue = dispatchFunction(action)
+
+        return returnValue
     }
 
     public func dispatch(actionCreatorProvider: ActionCreator) -> Any {
-        return dispatch(actionCreatorProvider, callback: nil)
+        let action = actionCreatorProvider(state: state, store: self)
+
+        if let action = action {
+            dispatch(action)
+        }
+
+        return action
     }
 
     public func dispatch(asyncActionCreatorProvider: AsyncActionCreator) {
         dispatch(asyncActionCreatorProvider, callback: nil)
     }
 
-    public func dispatch(action: Action, callback: DispatchCallback?) -> Any {
-        let returnValue = dispatchFunction(action)
-        callback?(state)
-
-        return returnValue
-    }
-
-    public func dispatch(actionCreatorProvider: ActionCreator, callback: DispatchCallback?) -> Any {
-        let action = actionCreatorProvider(state: state, store: self)
-
-        if let action = action {
-            dispatch(action, callback: callback)
-        }
-
-        return action
-    }
-
     public func dispatch(actionCreatorProvider: AsyncActionCreator, callback: DispatchCallback?) {
         actionCreatorProvider(state: state, store: self) { actionProvider in
-            self.dispatch(actionProvider, callback: callback)
+            let action = actionProvider(state: self.state, store: self)
+
+            if let action = action {
+                self.dispatch(action)
+                callback?(self.state)
+            }
         }
     }
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -1,6 +1,6 @@
 //
 //  Store.swift
-//  SwiftFlow
+//  ReSwift
 //
 //  Created by Benjamin Encz on 11/28/15.
 //  Copyright © 2015 DigiTales. All rights reserved.
@@ -79,14 +79,14 @@ public protocol StoreType {
 
      ```
      func deleteNote(noteID: Int) -> ActionCreator {
-     return { state, store in
-     // only delete note if editing is enabled
-     if (state.editingEnabled == true) {
-     return NoteDataAction.DeleteNote(noteID)
-     } else {
-     return nil
-     }
-     }
+        return { state, store in
+            // only delete note if editing is enabled
+            if (state.editingEnabled == true) {
+                return NoteDataAction.DeleteNote(noteID)
+            } else {
+                return nil
+            }
+        }
      }
      ```
 
@@ -106,65 +106,6 @@ public protocol StoreType {
      action creator asynchronously.
      */
     func dispatch(asyncActionCreator: AsyncActionCreator)
-
-    /**
-     Dispatches an action and calls the callback as soon as the action has been processed.
-     You will receive the updated store state as part of this callback.
-
-     Example of dispatching an action and implementing a callback:
-
-     ```
-     store.dispatch( CounterAction.IncreaseCounter ) { state in
-     print("New state: \(state)")
-     }
-     ```
-
-     - parameter action: The action that is being dispatched to the store
-     - returns: By default returns the dispatched action, but middlewares can change the
-     return type, e.g. to return promises
-     */
-    func dispatch(action: Action, callback: DispatchCallback?) -> Any
-
-    /**
-     Dispatches an action creator to the store. Action creators are functions that generate
-     actions. They are called by the store and receive the current state of the application
-     and a reference to the store as their input.
-
-     Based on that input the action creator can either return an action or not. Alternatively
-     the action creator can also perform an asynchronous operation and dispatch a new action
-     at the end of it.
-
-     Example of an action creator:
-
-     ```
-     func deleteNote(noteID: Int) -> ActionCreator {
-     return { state, store in
-     // only delete note if editing is enabled
-     if (state.editingEnabled == true) {
-     return NoteDataAction.DeleteNote(noteID)
-     } else {
-     return nil
-     }
-     }
-     }
-     ```
-
-     This action creator can then be dispatched as following:
-
-     ```
-     store.dispatch( noteActionCreatore.deleteNote(3) )
-     ```
-
-     This overloaded version of `dispatch` will call the provided `callback` as soon as a new
-     state has been calculated based on the dispatch action.
-
-     - Note: If the ActionCreator does not dispatch an action, the callback block will never
-     be called
-
-     - returns: By default returns the dispatched action, but middlewares can change the
-     return type, e.g. to return promises
-     */
-    func dispatch(actionCreator: ActionCreator, callback: DispatchCallback?) -> Any
 
     /**
      Dispatches an async action creator to the store. An async action creator generates an
@@ -197,14 +138,14 @@ public protocol StoreType {
 
      ```
      func deleteNote(noteID: Int) -> ActionCreator {
-     return { state, store in
-     // only delete note if editing is enabled
-     if (state.editingEnabled == true) {
-     return NoteDataAction.DeleteNote(noteID)
-     } else {
-     return nil
-     }
-     }
+        return { state, store in
+            // only delete note if editing is enabled
+            if (state.editingEnabled == true) {
+                return NoteDataAction.DeleteNote(noteID)
+            } else {
+                return nil
+            }
+        }
      }
      ```
 


### PR DESCRIPTION
Using ReSwift there should never be a reason for needing a callback upon state update for synchronous dispatches. This was correctly pointed out in #75.