### PR TITLE
Fixed compiler warnings due to usage of typealias when declaring associated types

### DIFF
--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -13,7 +13,7 @@ public protocol AnyReducer {
 }
 
 public protocol Reducer: AnyReducer {
-    typealias ReducerStateType
+    associatedtype ReducerStateType
 
     func handleAction(action: Action, state: ReducerStateType?) -> ReducerStateType
 }

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -13,7 +13,7 @@ public protocol AnyStoreSubscriber: class {
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {
-    typealias StoreSubscriberStateType
+    associatedtype StoreSubscriberStateType
 
     func newState(state: StoreSubscriberStateType)
 }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -16,7 +16,7 @@ import Foundation
  */
 public protocol StoreType {
 
-    typealias State: StateType
+    associatedtype State: StateType
 
     /// Initializes the store with a reducer and an intial state.
     init(reducer: AnyReducer, state: State?)
@@ -128,7 +128,7 @@ public protocol StoreType {
      a successful login). However, you should try to use this callback very seldom as it
      deviates slighlty from the unidirectional data flow principal.
      */
-    typealias DispatchCallback = (State) -> Void
+    associatedtype DispatchCallback = (State) -> Void
 
     /**
      An ActionCreator is a function that, based on the received state argument, might or might not
@@ -150,9 +150,9 @@ public protocol StoreType {
      ```
 
      */
-    typealias ActionCreator = (state: State, store: StoreType) -> Action?
+    associatedtype ActionCreator = (state: State, store: StoreType) -> Action?
 
     /// AsyncActionCreators allow the developer to wait for the completion of an async action.
-    typealias AsyncActionCreator = (state: State, store: StoreType,
+    associatedtype AsyncActionCreator = (state: State, store: StoreType,
     actionCreatorCallback: ActionCreator -> Void) -> Void
 }


### PR DESCRIPTION
In the latest Xcode version, the compiler gives the following warning when `typealias` is used to declare an associated type on a protocol:

    Use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead

I fixed all the occurrences of this warning using Xcode's hotfix functionality and simply replaced `typealias` with `associatedtype`.