### PR TITLE
missing renames of "MainStore" -> "Store" and "Store" -> "StoreType" in docs and comments

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -268,7 +268,7 @@ let loggingMiddleware: Middleware = { dispatch, getState in
 You can define which middleware you would like to use when creating your store:
 
 ```swift
-MainStore(reducer: reducer, appState: TestStringAppState(),
+Store(reducer: reducer, appState: TestStringAppState(),
                     middleware: [loggingMiddleware, secondMiddleware])
 ```
 The actions will pass through the middleware in the order in which they are arranged in the array passed to the store initializer, however ideally middleware should not make any assumptions about when exactly it is called.

--- a/ReSwift/CoreTypes/CombinedReducer.swift
+++ b/ReSwift/CoreTypes/CombinedReducer.swift
@@ -13,7 +13,7 @@ import Foundation
 
  ```swift
  let reducer = CombinedReducer([IncreaseByOneReducer(), IncreaseByTwoReducer()])
- MainStore(reducer: reducer, appState: CounterState())
+ Store(reducer: reducer, appState: CounterState())
  ```
 
  The order of the reducers in the array is the order in which the reducers will be invoked.

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -1,5 +1,5 @@
 //
-//  MainStore.swift
+//  Store.swift
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/11/15.

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -1,5 +1,5 @@
 //
-//  Store.swift
+//  StoreType.swift
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/28/15.
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- Defines the interface of Stores in Swift Flow. `MainStore` is the default implementation of this
+ Defines the interface of Stores in Swift Flow. `Store` is the default implementation of this
  interaface. Applications have a single store that stores the entire application state.
  Stores receive actions and use reducers combined with these actions, to calculate state changes.
  Upon every state update a store informs all of its subscribers.


### PR DESCRIPTION
Fixes a few boiler plates, comments and documentations that were using the old naming conventions.