### PR TITLE
Fix an example code of asynchronous operation in the documentation.

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -207,14 +207,12 @@ func fetchGitHubRepositories(state: State, store: Store<State>) -> Action? {
     guard case let .LoggedIn(configuration) = state.authenticationState.loggedInState  else { return nil }
 
     Octokit(configuration).repositories { response in
-    	store.dispatch(SetRepositories(repositories: .Loading))
-    
         dispatch_async(dispatch_get_main_queue()) {
             store.dispatch(SetRepostories(repositories: `.Repositories(response)))
         }
     }
 
-    return nil
+    return SetRepositories(repositories: .Loading)
 }
 ```
 


### PR DESCRIPTION
The example code in the doc seems to be wrong. `SetRepositories(repositories: .Loading)` should be dispatched as soon as the network request starts, but the action in the original example is dispatched just after the request is finished.

Does this modification reflect an intention of the documentation correctly?