### PR TITLE
[Docs] Add Gitter Link and Product Hunt Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ReSwift is quickly growing beyond the core library, providing experimental exten
 
 Excited? So are we 🎉
 
+Check out our [public gitter chat!](https://gitter.im/ReSwift/public)
+
 # Table of Contents
 
 - [About ReSwift](#about-reswift)
@@ -195,6 +197,10 @@ This repository contains the core component for ReSwift, the following extension
 - [GitHubBrowserExample](https://github.com/ReSwift/GitHubBrowserExample): A real world example, involving authentication, network requests and navigation. Still WIP but should be the best resource for starting to adapt `ReSwift` in your own app.
 - [Meet](https://github.com/Ben-G/Meet): A real world application being built with ReSwift - currently still very early on. It is not up to date with the latest version of ReSwift, but is the best project for demonstrating time travel.
 
+##Production Apps with Open Source Code
+
+- [Product Hunt for OS X](https://github.com/producthunt/producthunt-osx) Official Product Hunt client for OS X.
+
 # Contributing
 
 There's still a lot of work to do here! We would love to see you involved! You can find all the details on how to get started in the [Contributing Guide](/CONTRIBUTING.md).
@@ -210,3 +216,6 @@ If you have any questions, you can find the core team on twitter:
 - [@benjaminencz](https://twitter.com/benjaminencz)
 - [@karlbowden](https://twitter.com/karlbowden)
 - [@ARendtslev](https://twitter.com/ARendtslev)
+
+We also have a [public gitter chat!](https://gitter.im/ReSwift/public)
+


### PR DESCRIPTION
Minor updates to include two links to our gitter channel and the Product Hunt OS X app written with ReSwift.