### PR TITLE
Chore: fix spelling in StoreType.swift

### DIFF
--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /**
  Defines the interface of Stores in Swift Flow. `Store` is the default implementation of this
- interaface. Applications have a single store that stores the entire application state.
+ interface. Applications have a single store that stores the entire application state.
  Stores receive actions and use reducers combined with these actions, to calculate state changes.
  Upon every state update a store informs all of its subscribers.
  */


### PR DESCRIPTION
* Just a minor spelling mistake I discovered while using this amazing library
* Change interaface to interface in top comment in StoreType.swift