### PR TITLE
[Swift3] Migrate project to support Swift 3

### DIFF
--- a/.jazzy.json
+++ b/.jazzy.json
@@ -1,5 +1,5 @@
 {
-    "xcodebuild_arguments": ["-project", "ReSwift.xcodeproj", "-scheme", "ReSwift-OSX"],
+    "xcodebuild_arguments": ["-project", "ReSwift.xcodeproj", "-scheme", "ReSwift-macOS"],
     "swift_version": "2.1.1",
     "author_name": "ReSwift",
     "author_url": "https://github.com/ReSwift/ReSwift",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #Upcoming Release
 
+**Other**:
+
+- Swift 3 preview compatibility, maintaining Swift 2 naming - (#126) @agentk
+
 #2.0.0
 
 *Released: 06/27/2016*

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -118,7 +118,7 @@
 		25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		621C06851C277759008029AE /* CombinedReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedReducerTests.swift; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625AA6311C33AFA600FEB431 /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSpec.swift; sourceTree = "<group>"; };
@@ -235,7 +235,7 @@
 				25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */,
 				25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */,
 				25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */,
-				25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */,
+				25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -402,9 +402,9 @@
 			productReference = 25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */ = {
+		25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSX" */;
+			buildConfigurationList = 25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOS" */;
 			buildPhases = (
 				25DBCF761C30C4AA00D63A58 /* Sources */,
 				25DBCF771C30C4AA00D63A58 /* Frameworks */,
@@ -415,14 +415,14 @@
 			);
 			dependencies = (
 			);
-			name = "ReSwift-OSX";
+			name = "ReSwift-macOS";
 			productName = "ReSwift-Mac";
 			productReference = 25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		25DBCF861C30C4DB00D63A58 /* ReSwift-OSXTests */ = {
+		25DBCF861C30C4DB00D63A58 /* ReSwift-macOSTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSXTests" */;
+			buildConfigurationList = 25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOSTests" */;
 			buildPhases = (
 				25DBCF831C30C4DB00D63A58 /* Sources */,
 				25DBCF841C30C4DB00D63A58 /* Frameworks */,
@@ -434,9 +434,9 @@
 			dependencies = (
 				25DBCF8E1C30C4DB00D63A58 /* PBXTargetDependency */,
 			);
-			name = "ReSwift-OSXTests";
+			name = "ReSwift-macOSTests";
 			productName = "ReSwift-MacTests";
-			productReference = 25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */;
+			productReference = 25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		625E66821C1FF97E0027C288 /* ReSwift-iOS */ = {
@@ -484,7 +484,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Benjamin Encz";
 				TargetAttributes = {
 					25DBCF361C30BF2B00D63A58 = {
@@ -498,9 +498,11 @@
 					};
 					25DBCF7A1C30C4AA00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					25DBCF861C30C4DB00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					625E66821C1FF97E0027C288 = {
 						CreatedOnToolsVersion = 7.1.1;
@@ -524,8 +526,8 @@
 			targets = (
 				625E66821C1FF97E0027C288 /* ReSwift-iOS */,
 				625E66991C1FFA3C0027C288 /* ReSwift-iOSTests */,
-				25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */,
-				25DBCF861C30C4DB00D63A58 /* ReSwift-OSXTests */,
+				25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */,
+				25DBCF861C30C4DB00D63A58 /* ReSwift-macOSTests */,
 				25DBCF4D1C30C18D00D63A58 /* ReSwift-tvOS */,
 				25DBCF631C30C1AC00D63A58 /* ReSwift-tvOSTests */,
 				25DBCF361C30BF2B00D63A58 /* ReSwift-watchOS */,
@@ -771,7 +773,7 @@
 		};
 		25DBCF8E1C30C4DB00D63A58 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */;
+			target = 25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */;
 			targetProxy = 25DBCF8D1C30C4DB00D63A58 /* PBXContainerItemProxy */;
 		};
 		625E66A11C1FFA3C0027C288 /* PBXTargetDependency */ = {
@@ -810,6 +812,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;
@@ -840,6 +843,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -871,6 +875,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -965,6 +970,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -990,6 +996,7 @@
 				PRODUCT_NAME = ReSwift;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1019,6 +1026,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1036,6 +1044,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = reswift.github.io.ReSwift;
 				PRODUCT_NAME = ReSwift;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -1071,6 +1081,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -1137,7 +1148,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSX" */ = {
+		25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				25DBCF811C30C4AA00D63A58 /* Debug */,
@@ -1146,7 +1157,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSXTests" */ = {
+		25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				25DBCF901C30C4DB00D63A58 /* Debug */,

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-OSX.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
                BuildableName = "ReSwift.framework"
-               BlueprintName = "ReSwift-OSX"
+               BlueprintName = "ReSwift-macOS"
                ReferencedContainer = "container:ReSwift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -34,8 +34,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "25DBCF861C30C4DB00D63A58"
-               BuildableName = "ReSwift-OSXTests.xctest"
-               BlueprintName = "ReSwift-OSXTests"
+               BuildableName = "ReSwift-macOSTests.xctest"
+               BlueprintName = "ReSwift-macOSTests"
                ReferencedContainer = "container:ReSwift.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -45,7 +45,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -67,7 +67,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -85,7 +85,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-iOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-tvOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-watchOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift/CoreTypes/CombinedReducer.swift
+++ b/ReSwift/CoreTypes/CombinedReducer.swift
@@ -31,7 +31,11 @@ public struct CombinedReducer: AnyReducer {
 
     public func _handleAction(action: Action, state: StateType?) -> StateType {
         return reducers.reduce(state) { (currentState, reducer) -> StateType in
-            reducer._handleAction(action, state: currentState)
+            #if swift(>=3)
+                return reducer._handleAction(action: action, state: currentState)
+            #else
+                return reducer._handleAction(action, state: currentState)
+            #endif
         }!
     }
 }

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public typealias DispatchFunction =  (Action) -> Any
 public typealias GetState = () -> StateType?
-public typealias Middleware = (DispatchFunction?, GetState) -> DispatchFunction -> DispatchFunction
+public typealias Middleware =
+    (DispatchFunction?, GetState) -> (DispatchFunction) -> DispatchFunction

--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -24,6 +24,10 @@ public protocol Reducer: AnyReducer {
 
 extension Reducer {
     public func _handleAction(action: Action, state: StateType?) -> StateType {
-        return withSpecificTypes(action, state: state, function: handleAction)
+        #if swift(>=3)
+            return withSpecificTypes(action: action, state: state, function: handleAction)
+        #else
+            return withSpecificTypes(action, state: state, function: handleAction)
+        #endif
     }
 }

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -25,7 +25,11 @@ public protocol StoreSubscriber: AnyStoreSubscriber {
 extension StoreSubscriber {
     public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
-            newState(typedState)
+            #if swift(>=3)
+                newState(state: typedState)
+            #else
+                newState(typedState)
+            #endif
         }
     }
 }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -167,7 +167,7 @@ public protocol StoreType {
     /// AsyncActionCreators allow the developer to wait for the completion of an async action.
     #if swift(>=2.2)
     associatedtype AsyncActionCreator = (state: State, store: StoreType,
-    actionCreatorCallback: ActionCreator -> Void) -> Void
+    actionCreatorCallback: (ActionCreator) -> Void) -> Void
     #else
     typealias AsyncActionCreator = (state: State, store: StoreType,
     actionCreatorCallback: ActionCreator -> Void) -> Void

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -10,5 +10,5 @@ import Foundation
 
 struct Subscription<State: StateType> {
     private(set) weak var subscriber: AnyStoreSubscriber? = nil
-    let selector: (State -> Any)?
+    let selector: ((State) -> Any)?
 }

--- a/ReSwift/Utils/TypeHelper.swift
+++ b/ReSwift/Utils/TypeHelper.swift
@@ -18,6 +18,23 @@ import Foundation
  - returns: A `StateType` from `handleAction` or the original `StateType` if it cannot be
             casted to `SpecificStateType`.
  */
+#if swift(>=3)
+func withSpecificTypes<SpecificStateType, Action>(
+        action: Action,
+        state genericStateType: StateType?,
+        function: @noescape (action: Action, state: SpecificStateType?) -> SpecificStateType
+    ) -> StateType {
+        guard let genericStateType = genericStateType else {
+            return function(action: action, state: nil) as! StateType
+        }
+
+        guard let specificStateType = genericStateType as? SpecificStateType else {
+            return genericStateType
+        }
+
+        return function(action: action, state: specificStateType) as! StateType
+}
+#else
 func withSpecificTypes<SpecificStateType, Action>(
         action: Action,
         state genericStateType: StateType?,
@@ -33,3 +50,4 @@ func withSpecificTypes<SpecificStateType, Action>(
 
         return function(action: action, state: specificStateType) as! StateType
 }
+#endif


### PR DESCRIPTION
It's time to open the discussion on how to handle Swift 3 migration.

We have a few options.

- Move to Swift 3 only support
- Support Swift 2...3 maintaining Swift 2 naming conventions
- Support Swift 2...3 using Swift 2 naming conventions for users of Swift 2, and Swift 3 naming for Swift 3 users
- Support Swift 2...3 using only Swift 3 naming conventions

It's actually quirt easy to still support Swift 2+ in the one project, and Swift 3/Xcode 8 will not be usable for submitting apps for a few months still, so I'd take the first option of the table.

Then that leaves us with the choice of naming conventions. For the interest of not breaking code, I would prefer to stick with Swift 2 naming (the current naming in ReSwift) conventions. It means we can:

- Release v2.1 with Swift 3 support as it is does not break API compatibility
- Users can move between Swift 2.2 and 3 without any changing any code that relies on ReSwift
- Release v3.0 where we break the API and move to Swift 3 naming conventions
- No documentation changes will be needed as the same usage applies

In this pull request I have:
- Added support for Swift 3
- All tests pass in Xcode 7.3.1 and Xcode 8
- Marked the project as migrated to Swift 3 and Xcode 8 in pbxproj
- Renamed the OS X target and scheme to macOS (this should not break anything as the target module is still called ReSwift)
- Enabled whole module optimisation as suggested by Xcode (again backwards compatible, Xcode 7.3 just ignores the setting)

Thoughts?
