### PR TITLE
Keep track of the previous state

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -21,6 +21,12 @@ public class Store<State: StateType>: StoreType {
 
     // TODO: Setter should not be public; need way for store enhancers to modify appState anyway
 
+    private var _previousState : State?
+    public var previousState: State? {
+        get {
+            return _previousState
+        }
+    }
     /*private (set)*/ public var state: State! {
         didSet {
             subscriptions = subscriptions.filter { $0.subscriber != nil }
@@ -155,7 +161,8 @@ public class Store<State: StateType>: StoreType {
             let newState = reducer._handleAction(action, state: state) as! State
         #endif
         isDispatching = false
-
+        
+        _previousState = state
         state = newState
 
         return action

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -21,7 +21,7 @@ public class Store<State: StateType>: StoreType {
 
     // TODO: Setter should not be public; need way for store enhancers to modify appState anyway
 
-    private var _previousState : State?
+    private var _previousState: State?
     public var previousState: State? {
         get {
             return _previousState
@@ -161,7 +161,7 @@ public class Store<State: StateType>: StoreType {
             let newState = reducer._handleAction(action, state: state) as! State
         #endif
         isDispatching = false
-        
+
         _previousState = state
         state = newState
 


### PR DESCRIPTION
Keep track of the previous state to make it possible to react to some specific changes rather than to a given value. For instance, you could do:

```swift
func newState(state: AppState) {
  if let previousState = mainStore.previousState {
    if (state.imageIsLoaded && !previousState.imageIsLoaded) {
      print("image has just loaded")
    }
  }
}
```