### PR TITLE
Fixes Xcode 8 Beta 3 warnings / errors

### DIFF
--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -52,7 +52,7 @@ extension StandardAction: Coding {
 
     public init?(dictionary: [String: AnyObject?]) {
         guard let type = dictionary[typeKey] as? String,
-          isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+          let isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
         self.type = type
         self.payload = dictionary[payloadKey] as? [String: AnyObject]
         self.isTypedAction = isTypedAction

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -85,7 +85,11 @@ public class Store<State: StateType>: StoreType {
             subscriptions.append(Subscription(subscriber: subscriber, selector: selector))
 
             if let state = self.state {
-                subscriber._newState(selector?(state) ?? state)
+                if let selectedState = selector?(state) {
+                    subscriber._newState(selectedState)
+                } else {
+                    subscriber._newState(state)
+                }
             }
     }
 


### PR DESCRIPTION
This PR aims to remove warnings and error introduced by the newest Xcode 8 Beta 3.

- Fixes compiler warning for explicit `let` in conditional unwrapping.
- Compiler seem to get confused on which `_newState` method to call, when really there's only one implementation. Differentiating the calls with `SelectedState` argument or `State` seem to do the trick, for now.

This PR will be followed by a `swiftlint` PR that silences a few warnings that currently surface on that branch.