### PR TITLE
Silences swiftlint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,4 @@ excluded: # paths to ignore during linting. overridden by `included`.
 
 disabled_rules: # rule identifiers to exclude from running
   - force_cast
+  - conditional_binding_cascade

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// swiftlint:disable line_length
 public typealias DispatchFunction =  (Action) -> Any
 public typealias GetState = () -> StateType?
 public typealias Middleware = (DispatchFunction?, GetState) -> (DispatchFunction) -> DispatchFunction
+// swiftlint:enable line_length

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -98,8 +98,9 @@ public class Store<State: StateType>: StoreType {
     public func _defaultDispatch(_ action: Action) -> Any {
         if isDispatching {
             // Use Obj-C exception since throwing of exceptions can be verified through tests
-            NSException.raise("SwiftFlow:IllegalDispatchFromReducer" as NSExceptionName, format: "Reducers may not " +
-                "dispatch actions.", arguments: getVaList(["nil"]))
+            NSException.raise("SwiftFlow:IllegalDispatchFromReducer" as NSExceptionName,
+                              format: "Reducers may not " + "dispatch actions.",
+                              arguments: getVaList(["nil"]))
         }
 
         isDispatching = true


### PR DESCRIPTION
This PR silences the few warnings `swiftlint` emits on `line_length` and `conditional_binding_cascade`.

I understand that these may not be present in master, but should probably be addressed nonetheless.

Is it my understand that the `todo` rule is kept intentionally to make them appear as warnings - which seem fair enough.