### PR TITLE
Updated to Xcode 8 Beta 3, new Swift 3 changes, Removed Quick/Nimble

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,4 @@
-excluded: # paths to ignore during linting. overridden by `included`.
-  - Carthage
-  - Pods
-
 disabled_rules: # rule identifiers to exclude from running
   - force_cast
+
+line_length: 110

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,59 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8
 
 branches:
   except:
     - gh-pages
 
-before_install:
-  - brew update
-  - brew install carthage || brew outdated carthage || brew upgrade carthage
-  - carthage version
-
-install:
-  - gem install xcpretty
-  - carthage bootstrap --no-use-binaries --platform Mac,iOS
-
 env:
   global:
-    - LC_CTYPE=en_US.UTF-8
     - LANG=en_US.UTF-8
-    - FRAMEWORK_NAME="ReSwift"
-    - IOS_SDK=iphonesimulator9.3
-    - OSX_SDK=macosx10.11
-    - TVOS_SDK=appletvsimulator9.2
-    - WATCHOS_SDK=watchsimulator2.2
+    - LC_ALL=en_US.UTF-8
+    - PROJECT="ReSwift.xcworkspace"
+    - IOS_FRAMEWORK_SCHEME="ReSwift-iOS"
+    - MACOS_FRAMEWORK_SCHEME="ReSwift-macOS"
+    - TVOS_FRAMEWORK_SCHEME="ReSwift-tvOS"
+    - WATCHOS_FRAMEWORK_SCHEME="ReSwift-watchOS"
+    - IOS_SDK=iphonesimulator10.0
+    - MACOS_SDK=macosx10.12
+    - TVOS_SDK=appletvsimulator10.0
+    - WATCHOS_SDK=watchsimulator3.0
+
   matrix:
-    - DESTINATION="OS=9.3,name=iPhone 6S Plus"     SCHEME="iOS"     SDK="$IOS_SDK"     ACTION="test"
+    - DESTINATION="OS=10.0,name=iPhone 5"           SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone 5S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone SE"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone 6"           SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone 6 Plus"      SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
+    - DESTINATION="arch=x86_64"                     SCHEME="$MACOS_FRAMEWORK_SCHEME"   SDK="$MACOS_SDK"   RUN_TESTS="YES"
+    - DESTINATION="OS=10.0,name=Apple TV 1080p"     SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES"
+    - DESTINATION="OS=3.0,name=Apple Watch - 38mm"  SCHEME="$WATCHOS_FRAMEWORK_SCHEME" SDK="$WATCHOS_SDK" RUN_TESTS="NO"
 
 script:
+  script: 
+  - swiftlint
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
-  - xcodebuild
-    -project "$FRAMEWORK_NAME.xcodeproj"
-    -scheme "$FRAMEWORK_NAME-$SCHEME"
-    -sdk "$SDK"
-    -destination "$DESTINATION"
-    -configuration Debug
-    ONLY_ACTIVE_ARCH=YES
-    GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
-    GCC_GENERATE_TEST_COVERAGE_FILES=YES
-    "$ACTION"
-    | xcpretty -c
+
+  # Build Framework in Debug and Run Tests if specified
+  - if [ $RUN_TESTS == "YES" ]; then
+      xcodebuild -PROJECT "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+    else
+      xcodebuild -PROJECT "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+    fi
+
+  # Build Framework in Release and Run Tests if specified
+  - if [ $RUN_TESTS == "YES" ]; then
+      xcodebuild -PROJECT "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+    else
+      xcodebuild -PROJECT "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J ReSwift
-
-before_deploy:
-  - carthage build --no-skip-current
-  - carthage archive $FRAMEWORK_NAME
 
 deploy:
   provider: releases

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,0 @@
-github "Quick/Quick"
-github "Quick/Nimble"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "Quick/Nimble" "v4.0.0"
-github "Quick/Quick" "v0.9.2"

--- a/README.md
+++ b/README.md
@@ -183,16 +183,6 @@ You can install ReSwift via [Carthage](https://github.com/Carthage/Carthage) by 
 
     github "ReSwift/ReSwift"
 
-# Checking out Source Code
-
-After cloning this repository you need to use carthage to install testing frameworks that ReSwift depends on.
-
-Due to an [issue in Nimble](https://github.com/Quick/Nimble/issues/213) at the moment, tvOS tests will fail if building Nimble / Quick from source. You can however install Nimble & Quick from binaries then rebuild OS X & iOS only. After checkout, run the following from the terminal:
-
-```bash
-carthage bootstrap && carthage bootstrap --no-use-binaries --platform ios,osx
-```
-
 # Demo
 
 Using this library you can implement apps that have an explicit, reproducible state, allowing you, among many other things, to replay and rewind the app state, as shown below:

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -11,12 +11,8 @@
 		252982EF1C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
 		252982F01C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
 		252982F11C4FD21400281098 /* StoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252982ED1C4FD21400281098 /* StoreType.swift */; };
-		259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
 		259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FA1C2C618A00869B8F /* TestFakes.swift */; };
 		259737FD1C2C661100869B8F /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FC1C2C661100869B8F /* Middleware.swift */; };
-		25AB3B811C54A84500A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
-		25AB3B821C54A84600A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
-		25AB3B831C54A84700A41513 /* StoreSubscriberSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */; };
 		25DBCF3F1C30C16000D63A58 /* CombinedReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* CombinedReducer.swift */; };
 		25DBCF401C30C16000D63A58 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B61C1FFC880027C288 /* Action.swift */; };
 		25DBCF411C30C16000D63A58 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B71C1FFC880027C288 /* Store.swift */; };
@@ -36,10 +32,7 @@
 		25DBCF5E1C30C19500D63A58 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B11C1FFC830027C288 /* Coding.swift */; };
 		25DBCF5F1C30C19500D63A58 /* TypeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B21C1FFC830027C288 /* TypeHelper.swift */; };
 		25DBCF691C30C1AC00D63A58 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */; };
-		25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
-		25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
 		25DBCF731C30C34000D63A58 /* CombinedReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C06851C277759008029AE /* CombinedReducerTests.swift */; };
-		25DBCF741C30C34000D63A58 /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		25DBCF751C30C34000D63A58 /* TestFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FA1C2C618A00869B8F /* TestFakes.swift */; };
 		25DBCF8C1C30C4DB00D63A58 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */; };
 		25DBCF921C30C4F000D63A58 /* CombinedReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* CombinedReducer.swift */; };
@@ -51,19 +44,26 @@
 		25DBCF991C30C4F000D63A58 /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FC1C2C661100869B8F /* Middleware.swift */; };
 		25DBCF9A1C30C4F000D63A58 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B11C1FFC830027C288 /* Coding.swift */; };
 		25DBCF9B1C30C4F000D63A58 /* TypeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B21C1FFC830027C288 /* TypeHelper.swift */; };
-		25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
-		25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
 		25DBCF9E1C30C50000D63A58 /* CombinedReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C06851C277759008029AE /* CombinedReducerTests.swift */; };
-		25DBCF9F1C30C50000D63A58 /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		25DBCFA01C30C50000D63A58 /* TestFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FA1C2C618A00869B8F /* TestFakes.swift */; };
+		2819E8E61D3F754A0051ED55 /* NSExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2819E8E51D3F754A0051ED55 /* NSExceptionCatcher.m */; };
+		2819E8E71D3F784B0051ED55 /* NSExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2819E8E51D3F754A0051ED55 /* NSExceptionCatcher.m */; };
+		2819E8E81D3F784C0051ED55 /* NSExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2819E8E51D3F754A0051ED55 /* NSExceptionCatcher.m */; };
+		28C9DE831D3F5CDD00C20C93 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9DE811D3F5CD200C20C93 /* TestCase.swift */; };
+		28C9DE841D3F5CDD00C20C93 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9DE811D3F5CD200C20C93 /* TestCase.swift */; };
+		28C9DE851D3F5CDE00C20C93 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9DE811D3F5CD200C20C93 /* TestCase.swift */; };
+		28C9DE861D3F68D100C20C93 /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
+		28C9DE871D3F68D100C20C93 /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
+		28C9DE881D3F68D200C20C93 /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
+		28D3A29A1D3E82E80014D7B3 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
+		28D3A29C1D3E82EA0014D7B3 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
+		28D3A29D1D3E82EB0014D7B3 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */; };
+		28D3A29E1D3E85430014D7B3 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
+		28D3A29F1D3E85440014D7B3 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
+		28D3A2A01D3E85440014D7B3 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
 		621C06861C277759008029AE /* CombinedReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C06851C277759008029AE /* CombinedReducerTests.swift */; };
-		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
-		625AA6331C33AFB600FEB431 /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* ActionSpec.swift */; };
-		625AA6341C33AFB700FEB431 /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* ActionSpec.swift */; };
-		625AA6351C33AFB800FEB431 /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* ActionSpec.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
-		625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
 		625E66B31C1FFC830027C288 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B11C1FFC830027C288 /* Coding.swift */; };
 		625E66B41C1FFC830027C288 /* TypeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B21C1FFC830027C288 /* TypeHelper.swift */; };
 		625E66BC1C1FFC880027C288 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B61C1FFC880027C288 /* Action.swift */; };
@@ -72,12 +72,6 @@
 		625E66BF1C1FFC880027C288 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B91C1FFC880027C288 /* State.swift */; };
 		625E66C11C1FFC880027C288 /* StoreSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */; };
 		625E67061C20032E0027C288 /* CombinedReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* CombinedReducer.swift */; };
-		73C85BC21C30E5C600EABD08 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BC01C30E5C600EABD08 /* Nimble.framework */; };
-		73C85BC31C30E5C600EABD08 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BC11C30E5C600EABD08 /* Quick.framework */; };
-		73C85BC71C30E5E900EABD08 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BC51C30E5E900EABD08 /* Nimble.framework */; };
-		73C85BC81C30E5E900EABD08 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BC61C30E5E900EABD08 /* Quick.framework */; };
-		73C85BCC1C30E5FC00EABD08 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BCA1C30E5FC00EABD08 /* Nimble.framework */; };
-		73C85BCD1C30E5FC00EABD08 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C85BCB1C30E5FC00EABD08 /* Quick.framework */; };
 		81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
 		81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
 		81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
@@ -118,7 +112,11 @@
 		25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReSwift-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2819E8E31D3F754A0051ED55 /* ReSwift-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReSwift-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
+		2819E8E41D3F754A0051ED55 /* NSExceptionCatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionCatcher.h; sourceTree = "<group>"; };
+		2819E8E51D3F754A0051ED55 /* NSExceptionCatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionCatcher.m; sourceTree = "<group>"; };
+		28C9DE811D3F5CD200C20C93 /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		621C06851C277759008029AE /* CombinedReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedReducerTests.swift; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625AA6311C33AFA600FEB431 /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSpec.swift; sourceTree = "<group>"; };
@@ -136,12 +134,6 @@
 		625E66B91C1FFC880027C288 /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSubscriber.swift; sourceTree = "<group>"; };
 		625E67051C20032E0027C288 /* CombinedReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedReducer.swift; sourceTree = "<group>"; };
-		73C85BC01C30E5C600EABD08 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		73C85BC11C30E5C600EABD08 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
-		73C85BC51C30E5E900EABD08 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
-		73C85BC61C30E5E900EABD08 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
-		73C85BCA1C30E5FC00EABD08 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
-		73C85BCB1C30E5FC00EABD08 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		81BCBECD1C63167A00AA4F03 /* Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -165,8 +157,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF691C30C1AC00D63A58 /* ReSwift.framework in Frameworks */,
-				73C85BCC1C30E5FC00EABD08 /* Nimble.framework in Frameworks */,
-				73C85BCD1C30E5FC00EABD08 /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -182,8 +172,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF8C1C30C4DB00D63A58 /* ReSwift.framework in Frameworks */,
-				73C85BC71C30E5E900EABD08 /* Nimble.framework in Frameworks */,
-				73C85BC81C30E5E900EABD08 /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,22 +187,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */,
-				73C85BC21C30E5C600EABD08 /* Nimble.framework in Frameworks */,
-				73C85BC31C30E5C600EABD08 /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		621C06181C276A5A008029AE /* Frameworks iOS */ = {
+		2819E8E21D3F74DA0051ED55 /* NSExceptionHelper */ = {
 			isa = PBXGroup;
 			children = (
-				73C85BC01C30E5C600EABD08 /* Nimble.framework */,
-				73C85BC11C30E5C600EABD08 /* Quick.framework */,
+				2819E8E41D3F754A0051ED55 /* NSExceptionCatcher.h */,
+				2819E8E51D3F754A0051ED55 /* NSExceptionCatcher.m */,
+				2819E8E31D3F754A0051ED55 /* ReSwift-Tests-Bridging-Header.h */,
 			);
-			name = "Frameworks iOS";
-			path = ..;
+			name = NSExceptionHelper;
 			sourceTree = "<group>";
 		};
 		625E66791C1FF97E0027C288 = {
@@ -235,7 +221,7 @@
 				25DBCF4E1C30C18D00D63A58 /* ReSwift.framework */,
 				25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */,
 				25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */,
-				25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */,
+				25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -254,6 +240,7 @@
 		625E669B1C1FFA3C0027C288 /* ReSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
+				2819E8E21D3F74DA0051ED55 /* NSExceptionHelper */,
 				625E669E1C1FFA3C0027C288 /* Info.plist */,
 				621C06851C277759008029AE /* CombinedReducerTests.swift */,
 				259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */,
@@ -262,9 +249,7 @@
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
 				625AA6311C33AFA600FEB431 /* ActionSpec.swift */,
 				25AB3B7F1C54A79F00A41513 /* StoreSubscriberSpec.swift */,
-				621C06181C276A5A008029AE /* Frameworks iOS */,
-				73C85BC41C30E5D600EABD08 /* Frameworks OSX */,
-				73C85BC91C30E5ED00EABD08 /* Frameworks tvOS */,
+				28C9DE811D3F5CD200C20C93 /* TestCase.swift */,
 			);
 			path = ReSwiftTests;
 			sourceTree = "<group>";
@@ -292,24 +277,6 @@
 				81BCBECD1C63167A00AA4F03 /* Subscription.swift */,
 			);
 			path = CoreTypes;
-			sourceTree = "<group>";
-		};
-		73C85BC41C30E5D600EABD08 /* Frameworks OSX */ = {
-			isa = PBXGroup;
-			children = (
-				73C85BC51C30E5E900EABD08 /* Nimble.framework */,
-				73C85BC61C30E5E900EABD08 /* Quick.framework */,
-			);
-			name = "Frameworks OSX";
-			sourceTree = "<group>";
-		};
-		73C85BC91C30E5ED00EABD08 /* Frameworks tvOS */ = {
-			isa = PBXGroup;
-			children = (
-				73C85BCA1C30E5FC00EABD08 /* Nimble.framework */,
-				73C85BCB1C30E5FC00EABD08 /* Quick.framework */,
-			);
-			name = "Frameworks tvOS";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -390,7 +357,6 @@
 				25DBCF601C30C1AC00D63A58 /* Sources */,
 				25DBCF611C30C1AC00D63A58 /* Frameworks */,
 				25DBCF621C30C1AC00D63A58 /* Resources */,
-				73C85BCF1C30E73A00EABD08 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -402,9 +368,9 @@
 			productReference = 25DBCF641C30C1AC00D63A58 /* ReSwift-tvOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */ = {
+		25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSX" */;
+			buildConfigurationList = 25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOS" */;
 			buildPhases = (
 				25DBCF761C30C4AA00D63A58 /* Sources */,
 				25DBCF771C30C4AA00D63A58 /* Frameworks */,
@@ -415,28 +381,27 @@
 			);
 			dependencies = (
 			);
-			name = "ReSwift-OSX";
+			name = "ReSwift-macOS";
 			productName = "ReSwift-Mac";
 			productReference = 25DBCF7B1C30C4AA00D63A58 /* ReSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		25DBCF861C30C4DB00D63A58 /* ReSwift-OSXTests */ = {
+		25DBCF861C30C4DB00D63A58 /* ReSwift-macOSTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSXTests" */;
+			buildConfigurationList = 25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOSTests" */;
 			buildPhases = (
 				25DBCF831C30C4DB00D63A58 /* Sources */,
 				25DBCF841C30C4DB00D63A58 /* Frameworks */,
 				25DBCF851C30C4DB00D63A58 /* Resources */,
-				73C85BD01C30F34300EABD08 /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				25DBCF8E1C30C4DB00D63A58 /* PBXTargetDependency */,
 			);
-			name = "ReSwift-OSXTests";
+			name = "ReSwift-macOSTests";
 			productName = "ReSwift-MacTests";
-			productReference = 25DBCF871C30C4DB00D63A58 /* ReSwift-OSXTests.xctest */;
+			productReference = 25DBCF871C30C4DB00D63A58 /* ReSwift-macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		625E66821C1FF97E0027C288 /* ReSwift-iOS */ = {
@@ -465,7 +430,6 @@
 				625E66961C1FFA3C0027C288 /* Sources */,
 				625E66971C1FFA3C0027C288 /* Frameworks */,
 				625E66981C1FFA3C0027C288 /* Resources */,
-				73C85BCE1C30E70500EABD08 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -489,18 +453,23 @@
 				TargetAttributes = {
 					25DBCF361C30BF2B00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					25DBCF4D1C30C18D00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					25DBCF631C30C1AC00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					25DBCF7A1C30C4AA00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					25DBCF861C30C4DB00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					625E66821C1FF97E0027C288 = {
 						CreatedOnToolsVersion = 7.1.1;
@@ -526,8 +495,8 @@
 			targets = (
 				625E66821C1FF97E0027C288 /* ReSwift-iOS */,
 				625E66991C1FFA3C0027C288 /* ReSwift-iOSTests */,
-				25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */,
-				25DBCF861C30C4DB00D63A58 /* ReSwift-OSXTests */,
+				25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */,
+				25DBCF861C30C4DB00D63A58 /* ReSwift-macOSTests */,
 				25DBCF4D1C30C18D00D63A58 /* ReSwift-tvOS */,
 				25DBCF631C30C1AC00D63A58 /* ReSwift-tvOSTests */,
 				25DBCF361C30BF2B00D63A58 /* ReSwift-watchOS */,
@@ -599,52 +568,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		73C85BCE1C30E70500EABD08 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Quick.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		73C85BCF1C30E73A00EABD08 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/tvOS/Nimble.framework",
-				"$(SRCROOT)/Carthage/Build/tvOS/Quick.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		73C85BD01C30F34300EABD08 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/Mac/Nimble.framework",
-				"$(SRCROOT)/Carthage/Build/Mac/Quick.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -689,13 +613,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
-				25AB3B831C54A84700A41513 /* StoreSubscriberSpec.swift in Sources */,
-				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
-				625AA6351C33AFB800FEB431 /* ActionSpec.swift in Sources */,
+				28D3A29D1D3E82EB0014D7B3 /* StoreMiddlewareTests.swift in Sources */,
+				28C9DE881D3F68D200C20C93 /* TypeHelperTests.swift in Sources */,
+				28C9DE851D3F5CDE00C20C93 /* TestCase.swift in Sources */,
 				25DBCF731C30C34000D63A58 /* CombinedReducerTests.swift in Sources */,
-				25DBCF741C30C34000D63A58 /* TypeHelperTests.swift in Sources */,
 				25DBCF751C30C34000D63A58 /* TestFakes.swift in Sources */,
+				2819E8E81D3F784C0051ED55 /* NSExceptionCatcher.m in Sources */,
+				28D3A2A01D3E85440014D7B3 /* StoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -721,13 +645,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
-				25AB3B821C54A84600A41513 /* StoreSubscriberSpec.swift in Sources */,
-				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
-				625AA6341C33AFB700FEB431 /* ActionSpec.swift in Sources */,
+				28D3A29C1D3E82EA0014D7B3 /* StoreMiddlewareTests.swift in Sources */,
+				28C9DE871D3F68D100C20C93 /* TypeHelperTests.swift in Sources */,
+				28C9DE841D3F5CDD00C20C93 /* TestCase.swift in Sources */,
 				25DBCF9E1C30C50000D63A58 /* CombinedReducerTests.swift in Sources */,
-				25DBCF9F1C30C50000D63A58 /* TypeHelperTests.swift in Sources */,
 				25DBCFA01C30C50000D63A58 /* TestFakes.swift in Sources */,
+				2819E8E71D3F784B0051ED55 /* NSExceptionCatcher.m in Sources */,
+				28D3A29F1D3E85440014D7B3 /* StoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -753,13 +677,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */,
-				25AB3B811C54A84500A41513 /* StoreSubscriberSpec.swift in Sources */,
+				28D3A29A1D3E82E80014D7B3 /* StoreMiddlewareTests.swift in Sources */,
+				28C9DE861D3F68D100C20C93 /* TypeHelperTests.swift in Sources */,
+				28C9DE831D3F5CDD00C20C93 /* TestCase.swift in Sources */,
 				259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */,
-				625AA6331C33AFB600FEB431 /* ActionSpec.swift in Sources */,
-				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,
 				621C06861C277759008029AE /* CombinedReducerTests.swift in Sources */,
-				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,
+				2819E8E61D3F754A0051ED55 /* NSExceptionCatcher.m in Sources */,
+				28D3A29E1D3E85430014D7B3 /* StoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -773,7 +697,7 @@
 		};
 		25DBCF8E1C30C4DB00D63A58 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 25DBCF7A1C30C4AA00D63A58 /* ReSwift-OSX */;
+			target = 25DBCF7A1C30C4AA00D63A58 /* ReSwift-macOS */;
 			targetProxy = 25DBCF8D1C30C4DB00D63A58 /* PBXContainerItemProxy */;
 		};
 		625E66A11C1FFA3C0027C288 /* PBXTargetDependency */ = {
@@ -796,6 +720,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -813,6 +738,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;
@@ -828,6 +754,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -844,6 +771,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -851,31 +779,29 @@
 		25DBCF6D1C30C1AC00D63A58 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		25DBCF6E1C30C1AC00D63A58 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -893,6 +819,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -911,6 +838,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -919,16 +847,15 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -937,17 +864,16 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1088,15 +1014,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = reswift.github.io.ReSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -1106,15 +1029,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ReSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = reswift.github.io.ReSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "ReSwiftTests/ReSwift-Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
@@ -1150,7 +1070,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSX" */ = {
+		25DBCF801C30C4AA00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				25DBCF811C30C4AA00D63A58 /* Debug */,
@@ -1159,7 +1079,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-OSXTests" */ = {
+		25DBCF8F1C30C4DB00D63A58 /* Build configuration list for PBXNativeTarget "ReSwift-macOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				25DBCF901C30C4DB00D63A58 /* Debug */,

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-macOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-macOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
                BuildableName = "ReSwift.framework"
-               BlueprintName = "ReSwift-OSX"
+               BlueprintName = "ReSwift-macOS"
                ReferencedContainer = "container:ReSwift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -34,8 +34,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "25DBCF861C30C4DB00D63A58"
-               BuildableName = "ReSwift-OSXTests.xctest"
-               BlueprintName = "ReSwift-OSXTests"
+               BuildableName = "ReSwift-macOSTests.xctest"
+               BlueprintName = "ReSwift-macOSTests"
                ReferencedContainer = "container:ReSwift.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -45,7 +45,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -67,7 +67,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -85,7 +85,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "25DBCF7A1C30C4AA00D63A58"
             BuildableName = "ReSwift.framework"
-            BlueprintName = "ReSwift-OSX"
+            BlueprintName = "ReSwift-macOS"
             ReferencedContainer = "container:ReSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -51,8 +51,10 @@ private let isTypedActionKey = "isTypedAction"
 extension StandardAction: Coding {
 
     public init?(dictionary: [String: AnyObject?]) {
+        // swiftlint:disable conditional_binding_cascade
         guard let type = dictionary[typeKey] as? String,
-          isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+              let isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+        // swiftlint:enabled conditional_binding_cascade
         self.type = type
         self.payload = dictionary[payloadKey] as? [String: AnyObject]
         self.isTypedAction = isTypedAction

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -85,7 +85,8 @@ public class Store<State: StateType>: StoreType {
             subscriptions.append(Subscription(subscriber: subscriber, selector: selector))
 
             if let state = self.state {
-                subscriber._newState(selector?(state) ?? state)
+                let eitherState: Any = selector?(state) ?? state
+                subscriber._newState(eitherState)
             }
     }
 
@@ -98,7 +99,8 @@ public class Store<State: StateType>: StoreType {
     public func _defaultDispatch(_ action: Action) -> Any {
         if isDispatching {
             // Use Obj-C exception since throwing of exceptions can be verified through tests
-            NSException.raise("SwiftFlow:IllegalDispatchFromReducer" as NSExceptionName, format: "Reducers may not " +
+            NSException.raise("SwiftFlow:IllegalDispatchFromReducer" as NSExceptionName,
+                              format: "Reducers may not " +
                 "dispatch actions.", arguments: getVaList(["nil"]))
         }
 

--- a/ReSwiftTests/ActionSpec.swift
+++ b/ReSwiftTests/ActionSpec.swift
@@ -7,151 +7,152 @@
 //
 
 import XCTest
-import Quick
-import Nimble
 @testable import ReSwift
 
 // swiftlint:disable function_body_length
-class ActionSpec: QuickSpec {
+class ActionSpec: XCTest {
 
-    override func spec() {
-        describe("StandardAction") {
-
-            context("#init") {
-
-                it("can be initialized with just a type") {
-                    let action = StandardAction(type: "Test")
-
-                    expect(action.type).to(equal("Test"))
-                }
-
-                it("can be initialized with a type and a payload") {
-                    let action = StandardAction(type:"Test", payload: ["testKey": 5])
-
-                    let payload = action.payload!["testKey"]! as! Int
-
-                    expect(payload).to(equal(5))
-                    expect(action.type).to(equal("Test"))
-                }
-
-            }
-
-            context("#init-serialization") {
-
-                it("can initialize action with a dictionary") {
-                    let actionDictionary: [String: AnyObject?] = [
-                        "type": "TestType",
-                        "payload": nil,
-                        "isTypedAction": true
-                    ]
-
-                    let action = StandardAction(dictionary: actionDictionary)
-
-                    expect(action?.type).to(equal("TestType"))
-                    expect(action?.payload).to(beNil())
-                    expect(action?.isTypedAction).to(equal(true))
-                }
-
-                it("can convert an action to a dictionary") {
-                    let action = StandardAction(type:"Test", payload: ["testKey": 5],
-                        isTypedAction: true)
-
-                    let dictionary = action.dictionaryRepresentation
-
-                    let type = dictionary["type"] as! String
-                    let payload = dictionary["payload"] as! [String: AnyObject]
-                    let isTypedAction = dictionary["isTypedAction"] as! Int
-
-                    expect(type).to(equal("Test"))
-                    expect(payload["testKey"] as? Int).to(equal(5))
-                    expect(isTypedAction).to(equal(1))
-                }
-
-                it("can serialize / deserialize actions with payload and without custom type") {
-                    let action = StandardAction(type:"Test", payload: ["testKey": 5])
-                    let dictionary = action.dictionaryRepresentation
-
-                    let deserializedAction = StandardAction(dictionary: dictionary)
-
-                    let payload = deserializedAction?.payload?["testKey"] as? Int
-
-                    expect(payload).to(equal(5))
-                    expect(deserializedAction?.type).to(equal("Test"))
-                }
-
-                it("can serialize / deserialize actions with payload and with custom type") {
-                    let action = StandardAction(type:"Test", payload: ["testKey": 5],
-                                    isTypedAction: true)
-                    let dictionary = action.dictionaryRepresentation
-
-                    let deserializedAction = StandardAction(dictionary: dictionary)
-
-                    let payload = deserializedAction?.payload?["testKey"] as? Int
-
-                    expect(payload).to(equal(5))
-                    expect(deserializedAction?.type).to(equal("Test"))
-                    expect(deserializedAction?.isTypedAction).to(equal(true))
-                }
-
-                it("can serialize / deserialize actions without payload and without custom type") {
-                    let action = StandardAction(type:"Test", payload: nil)
-                    let dictionary = action.dictionaryRepresentation
-
-                    let deserializedAction = StandardAction(dictionary: dictionary)
-
-                    expect(deserializedAction?.payload).to(beNil())
-                    expect(deserializedAction?.type).to(equal("Test"))
-                }
-
-                it("can serialize / deserialize actions without payload and with custom type") {
-                    let action = StandardAction(type:"Test", payload: nil,
-                        isTypedAction: true)
-                    let dictionary = action.dictionaryRepresentation
-
-                    let deserializedAction = StandardAction(dictionary: dictionary)
-
-                    expect(deserializedAction?.payload).to(beNil())
-                    expect(deserializedAction?.type).to(equal("Test"))
-                    expect(deserializedAction?.isTypedAction).to(equal(true))
-                }
-
-                it("initializer returns nil when invalid dictionary is passed in") {
-                    let deserializedAction = StandardAction(dictionary: [:])
-
-                    expect(deserializedAction).to(beNil())
-                }
-            }
-        }
-
-        describe("StandardActionConvertible") {
-
-            context("#init") {
-
-                it("can be initialized with a standard action") {
-                    let standardAction = StandardAction(type: "Test", payload: ["value": 10])
-                    let action = SetValueAction(standardAction)
-
-                    expect(action.value).to(equal(10))
-                }
-
-            }
-
-            context("#toStandardAction") {
-
-                it("can be converted to a standard action") {
-                    let action = SetValueAction(5)
-
-                    let standardAction = action.toStandardAction()
-
-                    expect(standardAction.type).to(equal("SetValueAction"))
-                    expect(standardAction.isTypedAction).to(equal(true))
-                    expect(standardAction.payload?["value"] as? Int).to(equal(5))
-                }
-
-            }
-
-        }
+    override func setUp() {
+        super.setUp()
     }
 
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // StandardAction
+    // #init
+    func testCanBeInitWithJustType() {
+    // can be initialized with just a type
+        let action = StandardAction(type: "Test")
+
+        XCTAssertEqual(action.type, "Test")
+    }
+
+    // can be initialized with a type and a payload
+    func testCanBeInitWithTypeAndPayload() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5])
+
+        let payload = action.payload!["testKey"]! as! Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(action.type, "Test")
+    }
+
+    // #init-serialization
+    // can initialize action with a dictionary
+    func testInitActionWithDict() {
+        let actionDictionary: [String: AnyObject?] = [
+            "type": "TestType",
+            "payload": nil,
+            "isTypedAction": true
+        ]
+
+        let action = StandardAction(dictionary: actionDictionary)
+
+        XCTAssertEqual(action.type, "TestType")
+        XCTAssertNil(action?.payload)
+        XCTAssertTrue(action?.isTypedAction)
+    }
+
+    // can convert an action to a dictionary
+    func testCanConvertActionToDict() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5],
+            isTypedAction: true)
+
+        let dictionary = action.dictionaryRepresentation
+
+        let type = dictionary["type"] as! String
+        let payload = dictionary["payload"] as! [String: AnyObject]
+        let isTypedAction = dictionary["isTypedAction"] as! Int
+
+        XCTAssertEqual(type, "Test")
+        XCTAssertEqual(payload["testKey"] as? Int, 5)
+        XCTAssertEqual(isTypedAction, 1)
+    }
+
+    // can serialize / deserialize actions with payload and without custom type
+    func testCanSerializeDeserializeActionsWithPayloadNoCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5])
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    // can serialize / deserialize actions with payload and with custom type
+    func testCanSerializeDeserializeActionsWithPayloadWithCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5],
+                        isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertTrue(deserializedAction?.isTypedAction)
+    }
+
+    // can serialize / deserialize actions without payload and without custom type
+    func testCanSerializeDeserializeActionsWithoutPayloadNoCustomType() {
+        let action = StandardAction(type:"Test", payload: nil)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        expect(deserializedAction?.payload).to(beNil())
+        expect(deserializedAction?.type).to(equal("Test"))
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    // can serialize / deserialize actions without payload and with custom type
+    func testCanSerializeDeserializeActionsWithoutPayloadWithCustomType() {
+        let action = StandardAction(type:"Test", payload: nil,
+            isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertTrue(deserializedAction?.isTypedAction)
+    }
+
+    // initializer returns nil when invalid dictionary is passed in
+    func testInitReturnsNilWithInvalidDict() {
+        let deserializedAction = StandardAction(dictionary: [:])
+
+        XCTAssertNil(deserializedAction)
+    }
+
+    // StandardActionConvertible
+    // #init
+    // can be initialized with a standard action
+    func testCanBeInitWithStandardAction() {
+        let standardAction = StandardAction(type: "Test", payload: ["value": 10])
+        let action = SetValueAction(standardAction)
+
+        XCTAssertEqual(action.value, 10)
+    }
+
+    // #toStandardAction
+    // can be converted to a standard action
+    func testCanBeConvertedToStandardAction() {
+        let action = SetValueAction(5)
+
+        let standardAction = action.toStandardAction()
+
+        XCTAssertEqual(standardAction.type, "SetValueAction")
+        XCTAssertTrue(standardAction.isTypedAction)
+        XCTAssertEqual(standardAction.payload?["value"] as? Int, 5)
+    }
 }
 // swiftlint:enable function_body_length

--- a/ReSwiftTests/CombinedReducerTests.swift
+++ b/ReSwiftTests/CombinedReducerTests.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import Quick
-import Nimble
+import XCTest
 @testable import ReSwift
 
 class MockReducer: Reducer {
@@ -50,42 +49,44 @@ struct CounterState: StateType {
 let emptyAction = "EMPTY_ACTION"
 
 // swiftlint:disable function_body_length
-class CombinedReducerSpecs: QuickSpec {
+class CombinedReducerSpecs: XCTestCase {
 
-    override func spec() {
-        describe("Combined Reducer") {
+    override func setUp() {
+        super.setUp()
+    }
 
-            it("calls each of the reducers with the given action exactly once") {
-                let mockReducer1 = MockReducer()
-                let mockReducer2 = MockReducer()
+    override func tearDown() {
+        super.tearDown()
+    }
 
-                let combinedReducer = CombinedReducer([mockReducer1, mockReducer2])
+    func testCombinedReducer() {
+        // calls each of the reducers with the given action exactly once
+        let mockReducer1 = MockReducer()
+        let mockReducer2 = MockReducer()
 
-                combinedReducer._handleAction(
-                    StandardAction(type: emptyAction),
-                    state: CounterState()
-                )
+        let combinedReducer = CombinedReducer([mockReducer1, mockReducer2])
 
-                expect(mockReducer1.calledWithAction).to(haveCount(1))
-                expect(mockReducer2.calledWithAction).to(haveCount(1))
-                expect((mockReducer1.calledWithAction[0] as! StandardAction).type)
-                    .to(equal(emptyAction))
-                expect((mockReducer2.calledWithAction[0] as! StandardAction).type)
-                    .to(equal(emptyAction))
-            }
+        _ = combinedReducer._handleAction(
+            StandardAction(type: emptyAction),
+            state: CounterState()
+        )
 
-            it("combines the results from each individual reducer correctly") {
-                let increaseByOneReducer = IncreaseByOneReducer()
-                let increaseByTwoReducer = IncreaseByTwoReducer()
+        XCTAssertEqual(mockReducer1.calledWithAction.count, 1)
+        XCTAssertEqual(mockReducer2.calledWithAction.count, 1)
+        XCTAssertEqual((mockReducer1.calledWithAction[0] as! StandardAction).type, emptyAction)
+        XCTAssertEqual((mockReducer2.calledWithAction[0] as! StandardAction).type, emptyAction)
+    }
 
-                let combinedReducer = CombinedReducer([increaseByOneReducer, increaseByTwoReducer])
-                let newState = combinedReducer._handleAction(StandardAction(type: emptyAction),
-                    state: CounterState()) as? CounterState
+  func testCombinedReducerIndividual() {
+        // combines the results from each individual reducer correctly
+        let increaseByOneReducer = IncreaseByOneReducer()
+        let increaseByTwoReducer = IncreaseByTwoReducer()
 
-                expect(newState?.count).to(equal(3))
-            }
+        let combinedReducer = CombinedReducer([increaseByOneReducer, increaseByTwoReducer])
+        let newState = combinedReducer._handleAction(StandardAction(type: emptyAction),
+            state: CounterState()) as? CounterState
 
-        }
+        XCTAssertEqual(newState?.count, 3)
     }
 
 }

--- a/ReSwiftTests/NSExceptionCatcher.h
+++ b/ReSwiftTests/NSExceptionCatcher.h
@@ -1,0 +1,15 @@
+//
+//  NSExceptionCatcher.h
+//  ReSwift
+//
+//  Created by Madhava Jay on 20/07/2016.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSExceptionCatcher : NSObject
+
++ (BOOL) caughtException:(void (^_Nonnull)(void))handler;
+
+@end

--- a/ReSwiftTests/NSExceptionCatcher.m
+++ b/ReSwiftTests/NSExceptionCatcher.m
@@ -1,0 +1,24 @@
+//
+//  NSExceptionCatcher.m
+//  ReSwift
+//
+//  Created by Madhava Jay on 20/07/2016.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+#import "NSExceptionCatcher.h"
+
+@implementation NSExceptionCatcher
+
++ (BOOL) caughtException:(void (^_Nonnull)(void))handler {
+  BOOL exceptionRaised = NO;
+  @try {
+    handler();
+  }
+  @catch (NSException *exception) {
+    exceptionRaised = YES;
+  }
+  return exceptionRaised;
+}
+
+@end

--- a/ReSwiftTests/ReSwift-Tests-Bridging-Header.h
+++ b/ReSwiftTests/ReSwift-Tests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "NSExceptionCatcher.h"

--- a/ReSwiftTests/StoreSubscriberSpec.swift
+++ b/ReSwiftTests/StoreSubscriberSpec.swift
@@ -6,53 +6,57 @@
 //  Copyright © 2016 Benjamin Encz. All rights reserved.
 //
 
-import Quick
-import Nimble
+import XCTest
 @testable import ReSwift
 
 // swiftlint:disable function_body_length
-class FilteredStoreSpec: QuickSpec {
+class FilteredStoreSpec: XCTest {
 
-    override func spec() {
+    override func setUp() {
+        super.setUp()
+    }
 
-        describe("#subscribe") {
+    override func tearDown() {
+        super.tearDown()
+    }
 
-            it("allows to pass a state selector closure") {
-                let reducer = TestReducer()
-                let store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = TestFilteredSubscriber()
 
-                store.subscribe(subscriber) {
-                    $0.testValue
-                }
+    // #subscribe
+    // allows to pass a state selector closure
+    func testAllowsToPassAStateSelectorClosure() {
+        let reducer = TestReducer()
+        let store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = TestFilteredSubscriber()
 
-                store.dispatch(SetValueAction(3))
-
-                expect(subscriber.receivedValue).to(equal(3))
-            }
-
-            it("supports complex state selector closures") {
-                let reducer = TestComplexAppStateReducer()
-                let store = Store(reducer: reducer, state: TestComplexAppState())
-                let subscriber = TestSelectiveSubscriber()
-
-                store.subscribe(subscriber) {
-                    (
-                        $0.testValue,
-                        $0.otherState?.name
-                    )
-                }
-
-                store.dispatch(SetValueAction(5))
-                store.dispatch(SetOtherStateAction(
-                    otherState: OtherState(name: "TestName", age: 99)
-                ))
-
-                expect(subscriber.receivedValue.0).to(equal(5))
-                expect(subscriber.receivedValue.1).to(equal("TestName"))
-            }
+        store.subscribe(subscriber) {
+            $0.testValue
         }
 
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+    }
+
+    // supports complex state selector closures
+    func testSupportsComplexStateSelectorClosures() {
+        let reducer = TestComplexAppStateReducer()
+        let store = Store(reducer: reducer, state: TestComplexAppState())
+        let subscriber = TestSelectiveSubscriber()
+
+        store.subscribe(subscriber) {
+            (
+                $0.testValue,
+                $0.otherState?.name
+            )
+        }
+
+        store.dispatch(SetValueAction(5))
+        store.dispatch(SetOtherStateAction(
+            otherState: OtherState(name: "TestName", age: 99)
+        ))
+
+        XCTAssertEqual(subscriber.receivedValue.0, 5)
+        XCTAssertEqual(subscriber.receivedValue.1, "TestName")
     }
 
 }

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -7,239 +7,244 @@
 //
 
 import XCTest
-import Quick
-import Nimble
 @testable import ReSwift
 
 // swiftlint:disable function_body_length
 // swiftlint:disable type_body_length
-class StoreSpecs: QuickSpec {
+class StoreSpecs: XCTestCase {
 
-    override func spec() {
+    typealias TestSubscriber = TestStoreSubscriber<TestAppState>
 
-        describe("#init") {
+    var store: Store<TestAppState>!
+    var reducer: TestReducer!
 
-            it("Dispatches an Init action when it doesn't receive an initial state") {
-                let reducer = MockReducer()
-                let _ = Store<CounterState>(reducer: reducer, state: nil)
+    override func setUp() {
+      super.setUp()
+      reducer = TestReducer()
+      store = Store(reducer: reducer, state: TestAppState())
+    }
 
-                expect(reducer.calledWithAction[0] is ReSwiftInit).to(beTrue())
-            }
+    override func tearDown() {
+      super.tearDown()
+    }
 
-        }
+    func testInit() {
+      // init
+      // Dispatches an Init action when it doesn't receive an initial state
+      let reducer = MockReducer()
+      let _ = Store<CounterState>(reducer: reducer, state: nil)
 
-        describe("#deinit") {
-
-            it("Deinitializes when no reference is held") {
-                var deInitCount = 0
-
-                autoreleasepool {
-                    let reducer = TestReducer()
-                    let _ = DeInitStore(
-                        reducer: reducer,
-                        state: TestAppState(),
-                        deInitAction: { deInitCount += 1 })
-                }
-
-                expect(deInitCount).to(equal(1))
-            }
-
-        }
-
-        describe("#subscribe") {
-
-            var store: Store<TestAppState>!
-            var reducer: TestReducer!
-
-            typealias TestSubscriber = TestStoreSubscriber<TestAppState>
-
-            beforeEach {
-                reducer = TestReducer()
-                store = Store(reducer: reducer, state: TestAppState())
-            }
-
-            it("does not strongly capture an observer") {
-                store = Store(reducer: reducer, state: TestAppState())
-                var subscriber: TestSubscriber? = TestSubscriber()
-
-                store.subscribe(subscriber!)
-                expect(store.subscriptions.flatMap({ $0.subscriber }).count).to(equal(1))
-
-                subscriber = nil
-                expect(store.subscriptions.flatMap({ $0.subscriber })).to(beEmpty())
-            }
-
-            it("removes deferenced subscribers before notifying state changes") {
-                store = Store(reducer: reducer, state: TestAppState())
-                var subscriber1: TestSubscriber? = TestSubscriber()
-                var subscriber2: TestSubscriber? = TestSubscriber()
-
-                store.subscribe(subscriber1!)
-                store.subscribe(subscriber2!)
-                store.dispatch(SetValueAction(3))
-                expect(store.subscriptions.count).to(equal(2))
-                expect(subscriber1?.receivedStates.last?.testValue).to(equal(3))
-                expect(subscriber2?.receivedStates.last?.testValue).to(equal(3))
-
-                subscriber1 = nil
-                store.dispatch(SetValueAction(5))
-                expect(store.subscriptions.count).to(equal(1))
-                expect(subscriber2?.receivedStates.last?.testValue).to(equal(5))
-
-                subscriber2 = nil
-                store.dispatch(SetValueAction(8))
-                expect(store.subscriptions).to(beEmpty())
-            }
-
-            it("dispatches initial value upon subscription") {
-                store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = TestStoreSubscriber<TestAppState>()
-
-                store.subscribe(subscriber)
-                store.dispatch(SetValueAction(3))
-
-                expect(subscriber.receivedStates.last?.testValue).to(equal(3))
-            }
-
-            it("allows dispatching from within an observer") {
-                store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = DispatchingSubscriber(store: store)
-
-                store.subscribe(subscriber)
-                store.dispatch(SetValueAction(2))
-
-                expect(store.state.testValue).to(equal(5))
-            }
-
-            it("does not dispatch value after subscriber unsubscribes") {
-                store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = TestStoreSubscriber<TestAppState>()
-
-                store.dispatch(SetValueAction(5))
-                store.subscribe(subscriber)
-                store.dispatch(SetValueAction(10))
-
-                store.unsubscribe(subscriber)
-                // Following value is missed due to not being subscribed:
-                store.dispatch(SetValueAction(15))
-                store.dispatch(SetValueAction(25))
-
-                store.subscribe(subscriber)
-
-                store.dispatch(SetValueAction(20))
-
-                expect(subscriber.receivedStates.count).to(equal(4))
-
-                expect(subscriber.receivedStates[subscriber.receivedStates.count - 4]
-                    .testValue).to(equal(5))
-
-                expect(subscriber.receivedStates[subscriber.receivedStates.count - 3]
-                    .testValue).to(equal(10))
-
-                expect(subscriber.receivedStates[subscriber.receivedStates.count - 2]
-                    .testValue).to(equal(25))
-
-                expect(subscriber.receivedStates[subscriber.receivedStates.count - 1]
-                    .testValue).to(equal(20))
-            }
-
-            it("ignores identical subscribers") {
-                store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = TestStoreSubscriber<TestAppState>()
-
-                store.subscribe(subscriber)
-                store.subscribe(subscriber)
-
-                expect(store.subscriptions.count).to(equal(1))
-            }
-
-            it("ignores identical subscribers that provide substate selectors") {
-                store = Store(reducer: reducer, state: TestAppState())
-                let subscriber = TestStoreSubscriber<TestAppState>()
-
-                store.subscribe(subscriber) { $0 }
-                store.subscribe(subscriber) { $0 }
-
-                expect(store.subscriptions.count).to(equal(1))
-            }
-
-        }
-
-        describe("#dispatch") {
-
-            var store: Store<TestAppState>!
-            var reducer: TestReducer!
-
-            beforeEach {
-                reducer = TestReducer()
-                store = Store(reducer: reducer, state: TestAppState())
-            }
-
-            it("returns the dispatched action") {
-                let action = SetValueAction(10)
-                let returnValue = store.dispatch(action)
-
-                expect((returnValue as? SetValueAction)?.value).to(equal(action.value))
-            }
-
-            it("throws an exception when a reducer dispatches an action") {
-                // Expectation lives in the `DispatchingReducer` class
-                let reducer = DispatchingReducer()
-                store = Store(reducer: reducer, state: TestAppState())
-                reducer.store = store
-                store.dispatch(SetValueAction(10))
-            }
-
-            it("accepts action creators") {
-                store.dispatch(SetValueAction(5))
-
-                let doubleValueActionCreator: Store<TestAppState>.ActionCreator = { state, store in
-                    return SetValueAction(state.testValue! * 2)
-                }
-
-                store.dispatch(doubleValueActionCreator)
-
-                expect(store.state.testValue).to(equal(10))
-            }
-
-            it("accepts async action creators") {
-                let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
-                    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                        // Provide the callback with an action creator
-                        callback { state, store in
-                            return SetValueAction(5)
-                        }
-                    }
-                }
-
-                store.dispatch(asyncActionCreator)
-
-                expect(store.state.testValue).toEventually(equal(5))
-            }
-
-            it("calls the callback once state update from async action is complete") {
-                let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
-                    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                        // Provide the callback with an action creator
-                        callback { state, store in
-                            return SetValueAction(5)
-                        }
-                    }
-                }
-
-                waitUntil { fulfill in
-                    store.dispatch(asyncActionCreator) { newState in
-                        if newState.testValue == 5 {
-                            fulfill()
-                        }
-                    }
-                }
-            }
-
-        }
+      XCTAssertTrue(reducer.calledWithAction[0] is ReSwiftInit)
 
     }
 
+    func testDeInit() {
+        // deinit
+        // Deinitializes when no reference is held
+        var deInitCount = 0
+
+        autoreleasepool {
+            let reducer = TestReducer()
+            let _ = DeInitStore(
+                reducer: reducer,
+                state: TestAppState(),
+                deInitAction: { deInitCount += 1 })
+        }
+
+        XCTAssertEqual(deInitCount, 1)
+    }
+
+    func testSubscribeNotStronglyCaptureObserver() {
+        // subscribe
+        // does not strongly capture an observer
+
+        store = Store(reducer: reducer, state: TestAppState())
+        var subscriber: TestSubscriber? = TestSubscriber()
+
+        store.subscribe(subscriber!)
+        XCTAssertEqual(store.subscriptions.flatMap({ $0.subscriber }).count, 1)
+
+        subscriber = nil
+        XCTAssertEqual(store.subscriptions.flatMap({ $0.subscriber }).count, 0)
+    }
+
+    func testSubscribeRemovesDereferencedSubscribers() {
+        // removes deferenced subscribers before notifying state changes
+
+        store = Store(reducer: reducer, state: TestAppState())
+        var subscriber1: TestSubscriber? = TestSubscriber()
+        var subscriber2: TestSubscriber? = TestSubscriber()
+
+        store.subscribe(subscriber1!)
+        store.subscribe(subscriber2!)
+        store.dispatch(SetValueAction(3))
+        XCTAssertEqual(store.subscriptions.count, 2)
+        XCTAssertEqual(subscriber1?.receivedStates.last?.testValue, 3)
+        XCTAssertEqual(subscriber2?.receivedStates.last?.testValue, 3)
+
+        subscriber1 = nil
+        store.dispatch(SetValueAction(5))
+        XCTAssertEqual(store.subscriptions.count, 1)
+        XCTAssertEqual(subscriber2?.receivedStates.last?.testValue, 5)
+
+        subscriber2 = nil
+        store.dispatch(SetValueAction(8))
+        XCTAssertEqual(store.subscriptions.count, 0)
+    }
+
+    func testSubscribeDispatchesInitialValue() {
+        // dispatches initial value upon subscription
+        store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = TestStoreSubscriber<TestAppState>()
+
+        store.subscribe(subscriber)
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedStates.last?.testValue, 3)
+    }
+
+    func testSubscribeAllowsDispatchingFromObserver() {
+        // allows dispatching from within an observer
+        store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = DispatchingSubscriber(store: store)
+
+        store.subscribe(subscriber)
+        store.dispatch(SetValueAction(2))
+
+        XCTAssertEqual(store.state.testValue, 5)
+    }
+
+    func testSubscribeDoesNotDispatchValueAfterUnsubscribe() {
+        // does not dispatch value after subscriber unsubscribes
+        store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = TestStoreSubscriber<TestAppState>()
+
+        store.dispatch(SetValueAction(5))
+        store.subscribe(subscriber)
+        store.dispatch(SetValueAction(10))
+
+        store.unsubscribe(subscriber)
+        // Following value is missed due to not being subscribed:
+        store.dispatch(SetValueAction(15))
+        store.dispatch(SetValueAction(25))
+
+        store.subscribe(subscriber)
+
+        store.dispatch(SetValueAction(20))
+
+        XCTAssertEqual(subscriber.receivedStates.count, 4)
+
+        XCTAssertEqual(subscriber.receivedStates[subscriber.receivedStates.count - 4]
+            .testValue, 5)
+
+        XCTAssertEqual(subscriber.receivedStates[subscriber.receivedStates.count - 3]
+            .testValue, 10)
+
+        XCTAssertEqual(subscriber.receivedStates[subscriber.receivedStates.count - 2]
+            .testValue, 25)
+
+        XCTAssertEqual(subscriber.receivedStates[subscriber.receivedStates.count - 1]
+            .testValue, 20)
+    }
+
+    func testSubscribeIgnoresIdenticalSubscribers() {
+        // ignores identical subscribers
+        store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = TestStoreSubscriber<TestAppState>()
+
+        store.subscribe(subscriber)
+        store.subscribe(subscriber)
+
+        XCTAssertEqual(store.subscriptions.count, 1)
+    }
+
+    func testSubscribeIgnoresIdenticalSubscribersThatProvideSubstate() {
+        // ignores identical subscribers that provide substate selectors
+        store = Store(reducer: reducer, state: TestAppState())
+        let subscriber = TestStoreSubscriber<TestAppState>()
+
+        store.subscribe(subscriber) { $0 }
+        store.subscribe(subscriber) { $0 }
+
+        XCTAssertEqual(store.subscriptions.count, 1)
+    }
+
+    func testDispatchReturnsTheDispatchedAction() {
+        // dispatch
+        // returns the dispatched action
+        let action = SetValueAction(10)
+        let returnValue = store.dispatch(action)
+
+        XCTAssertEqual((returnValue as? SetValueAction)?.value, action.value)
+    }
+
+    func testThrowsExceptionWhenReducerDispatchesAction() {
+        // throws an exception when a reducer dispatches an action
+        // Expectation lives in the `DispatchingReducer` class
+        let reducer = DispatchingReducer()
+        store = Store(reducer: reducer, state: TestAppState())
+        reducer.store = store
+        store.dispatch(SetValueAction(10))
+    }
+
+    func testAcceptsActionCreators() {
+        // accepts action creators") {
+        store.dispatch(SetValueAction(5))
+
+        let doubleValueActionCreator: Store<TestAppState>.ActionCreator = { state, store in
+            return SetValueAction(state.testValue! * 2)
+        }
+
+        _ = store.dispatch(doubleValueActionCreator)
+
+        XCTAssertEqual(store.state.testValue, 10)
+    }
+
+    func testAcceptsAsyncActionCreators() {
+        // accepts async action creators
+        let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
+            let queue = DispatchQueue.global()
+            queue.async {
+                // Provide the callback with an action creator
+                callback { state, store in
+                    return SetValueAction(5)
+                }
+            }
+        }
+
+        store.dispatch(asyncActionCreator)
+
+        XCTAssertNil(self.store.state.testValue)
+        wait(1) {
+            XCTAssertEqual(self.store.state.testValue, 5)
+        }
+    }
+
+    func testCallsTheCallbackOnceUpdateFromAsyncComplete() {
+        // calls the callback once state update from async action is complete
+        let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
+            let queue = DispatchQueue.global()
+            queue.async {
+                // Provide the callback with an action creator
+                callback { state, store in
+                    return SetValueAction(5)
+                }
+            }
+        }
+
+        let promise = expectation(description: "wait")
+        self.store.dispatch(asyncActionCreator) { newState in
+            if newState.testValue == 5 {
+                promise.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: Double(1)) { error in
+            if let error = error {
+                XCTFail("Error: \(error.localizedDescription)")
+            }
+        }
+    }
 }
 
 // Used for deinitialization test
@@ -268,11 +273,13 @@ class DispatchingReducer: Reducer {
     var store: Store<TestAppState>? = nil
 
     func handleAction(_ action: Action, state: TestAppState?) -> TestAppState {
-        expect(self.store?.dispatch(SetValueAction(20))).to(raiseException(named:
-            "SwiftFlow:IllegalDispatchFromReducer"))
+        let raised = NSExceptionCatcher.caughtException {
+          self.store?.dispatch(SetValueAction(20))
+        }
+
+        XCTAssertTrue(raised)
         return state ?? TestAppState()
     }
 }
-
 // swiftlint:enable type_body_length
 // swiftlint:enable function_body_length

--- a/ReSwiftTests/TestCase.swift
+++ b/ReSwiftTests/TestCase.swift
@@ -1,0 +1,40 @@
+//
+//  TestCase.swift
+//  ReSwift
+//
+//  Created by Madhava Jay on 20/07/2016.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+// -------------------------------------------------------------------------------------------------
+// MARK: - Utility Base Class for Unit Tests
+// -------------------------------------------------------------------------------------------------
+extension XCTestCase {
+
+  func wait(_ seconds: Double, completionHandler: () -> Void) {
+    let promise = expectation(description: "wait")
+
+    fakeAsync(seconds) {
+      completionHandler()
+      promise.fulfill()
+    }
+
+    waitForExpectations(timeout: Double(seconds + 1)) { error in
+      if let error = error {
+        print("Error: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  func fakeAsync(_ seconds: Double, completionHandler: () -> Void) {
+    let globalQueue = DispatchQueue.global()
+    let time = DispatchTime.now() + seconds
+
+    globalQueue.after(when: time) {
+      completionHandler()
+    }
+  }
+}

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -7,62 +7,65 @@
 //
 
 import Foundation
-import Quick
-import Nimble
+import XCTest
 @testable import ReSwift
 
 struct AppState1: StateType {}
 struct AppState2: StateType {}
 
 // swiftlint:disable function_body_length
-class TypeHelper: QuickSpec {
+class TypeHelper: XCTestCase {
 
-    override func spec() {
+    override func setUp() {
+        super.setUp()
+    }
 
-        describe("f_withSpecificTypes") {
+    override func tearDown() {
+        super.tearDown()
+    }
 
-            it("calls methods if the source type can be casted into the function signature type") {
-                var called = false
-                let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
-                    called = true
+    // f_withSpecificTypes
 
-                    return state ?? AppState1()
-                }
+    func testCallsMethodsSourceCasted() {
+    // calls methods if the source type can be casted into the function signature type
+        var called = false
+        let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
+            called = true
 
-                withSpecificTypes(StandardAction(type: ""), state: AppState1(),
-                    function: reducerFunction)
-
-                expect(called).to(beTrue())
-            }
-
-            it("calls the method if the source type is nil") {
-                var called = false
-                let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
-                    called = true
-
-                    return state ?? AppState1()
-                }
-
-                withSpecificTypes(StandardAction(type: ""), state: nil,
-                    function: reducerFunction)
-
-                expect(called).to(beTrue())
-            }
-
-            it ("doesn't call if source type can't be casted to function signature type") {
-                var called = false
-                let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
-                    called = true
-
-                    return state ?? AppState1()
-                }
-
-                withSpecificTypes(StandardAction(type: ""), state: AppState2(),
-                    function: reducerFunction)
-
-                expect(called).to(beFalse())
-            }
+            return state ?? AppState1()
         }
+
+        _ = withSpecificTypes(StandardAction(type: ""), state: AppState1(), function: reducerFunction)
+
+        XCTAssertTrue(called)
+    }
+
+    func testCallsMethodIfSourceNil() {
+        // calls the method if the source type is nil") {
+        var called = false
+        let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
+            called = true
+
+            return state ?? AppState1()
+        }
+
+        _ = withSpecificTypes(StandardAction(type: ""), state: nil, function: reducerFunction)
+
+        XCTAssertTrue(called)
+    }
+
+    func testNotCalledIfSourceTypeCantBeCasted() {
+        // doesn't call if source type can't be casted to function signature type
+        var called = false
+        let reducerFunction: (Action, AppState1?) -> AppState1 = { action, state in
+            called = true
+
+            return state ?? AppState1()
+        }
+
+        _ = withSpecificTypes(StandardAction(type: ""), state: AppState2(), function: reducerFunction)
+
+        XCTAssertFalse(called)
     }
 }
 // swiftlint:enable function_body_length


### PR DESCRIPTION
Quick/Nimble aren't building in Carthage and waiting for final Swift 3 versions could be a long time. I don't think there is any need to have those two dependancies.

All tests have been changed to XCTest and the NSException has been tested with a tiny Objective-C single function helper method.

Without them the project is quicker and more nimble. :P

Tests pass locally, Travis CI isnt on Xcode 8 Beta 3 yet.