### PR TITLE
Xcode 8b3 fixes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,4 @@ excluded: # paths to ignore during linting. overridden by `included`.
 
 disabled_rules: # rule identifiers to exclude from running
   - force_cast
+  - conditional_binding_cascade

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -53,7 +53,7 @@ extension StandardAction: Coding {
 
     public init?(dictionary: [String: AnyObject]) {
         guard let type = dictionary[typeKey] as? String,
-          isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+          let isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
         self.type = type
         self.payload = dictionary[payloadKey] as? [String: AnyObject]
         self.isTypedAction = isTypedAction


### PR DESCRIPTION
This PR extracts the leftovers from #132 & #133 that were originally destined to the `swift-3` branch.

- Adds required explicit `let` on conditional binding cascade as per `SE-0099`.
- Adds `conditional_binding_cascade` to _swiftlint_'s disabled_rules (at least until it gets removed from _swiftlint_ altogether).

Thanks @agentk for the heads up on `master` being Swift 3 compatible!