### PR TITLE
[Swift 3] Support Swift Build with Latest Toolchain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "ReSwift"
+    name: "ReSwift",
+    exclude: [
+      "ReSwiftTests",
+      "Carthage",
+      "Docs"
+    ]
 )


### PR DESCRIPTION
Our `Package.swift` file has become a little bit outdated. With the following updates it's possible to use Swift build again.

Also requires a syntactical change that is also part of #139. Depending on when that is merged I'll take the change out of this PR. 