### PR TITLE
newState is called on subscribers before state changes

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -23,15 +23,15 @@ public class Store<State: StateType>: StoreType {
     // TODO: Setter should not be public; need way for store enhancers to modify appState anyway
 
     /*private (set)*/ public var state: State! {
-        didSet {
+        willSet(newState) {
             subscriptions = subscriptions.filter { $0.subscriber != nil }
             subscriptions.forEach {
                 // if a selector is available, subselect the relevant state
                 // otherwise pass the entire state to the subscriber
                 #if swift(>=3)
-                    $0.subscriber?._newState(state: $0.selector?(state) ?? state)
+                    $0.subscriber?._newState(state: $0.selector?(newState) ?? newState)
                 #else
-                    $0.subscriber?._newState($0.selector?(state) ?? state)
+                    $0.subscriber?._newState($0.selector?(newState) ?? newState)
                 #endif
             }
         }


### PR DESCRIPTION
**Related issue:** #144 

when newState is called, subscribers have newState value via parameter and also can have oldState value via store

#### Example: 

```swift
func newState(state: FooAppState) {
    if (store.state.FooLoadingState) {
        loadingView.hide()
    }

    switch state {
    case FooBlaBlaState:
    ...
    }
}
```