### PR TITLE
Wrap function in parenthesis to properly mark as escaping

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -245,7 +245,7 @@ public class Store<State: StateType>: StoreType {
     public typealias AsyncActionCreator = (
         _ state: State,
         _ store: Store,
-        _ actionCreatorCallback: @escaping (ActionCreator) -> Void
+        _ actionCreatorCallback: @escaping ((ActionCreator) -> Void)
     ) -> Void
     #else
     public typealias AsyncActionCreator = (


### PR DESCRIPTION
There appears to be a compiler bug that applies the escaping to the first argument (which is also a function) and not the entire function.