### PR TITLE
Updates documentation and error text to indicate concurrency requirements

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -193,7 +193,7 @@ func fetchGitHubRepositories(state: State, store: Store<State>) -> Action? {
 
 In this example we're using the `Octokit` library to perform a network request that fetches a users repositories. Within the callback block of the method we dispatch a state update that injects the received repositories into the app state. This will trigger all receivers to be informed about the new state.
 
-Note that the callback block from the network request arrives on a background thread, therefore we're using `dispatch_async(dispatch_get_main_queue())` to perform the state update on the main thread. `ReSwift` will call reducers and subscribers on whatever thread you have dispatched an action from. We recommend to always dispatch from the main thread, but `ReSwift` does not enforce this recommendation.
+Note that the callback block from the network request arrives on a background thread, therefore we're using `dispatch_async(dispatch_get_main_queue())` to perform the state update on the main thread. `ReSwift` will call reducers and subscribers on whatever thread you have dispatched an action from. We recommend to always dispatch from the main thread, but `ReSwift` does not enforce this recommendation. ReSwift *will* enforce that all Dispatches, Store Subscribes and Store Unsubscribes are on the same thread or serial Grand Central Dispatch queue. Therefore the main dispatch queue works, however the global dispatch queue, being concurrent, will fail.
 
 In many cases your asynchronous tasks will consist of two separate steps:
 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -107,9 +107,9 @@ open class Store<State: StateType>: StoreType {
     open func _defaultDispatch(action: Action) -> Void {
         guard !isDispatching else {
             raiseFatalError(
-                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: " + 
+                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: " +
                 " A reducer is dispatching an action," +
-                " multiple GCD queues are dispatching/subscribing to a single store," + 
+                " multiple GCD queues are dispatching/subscribing to a single store," +
                 " or a concurrent GCD queue (such as global()) is being used to" +
                 " dispatch/subscribe/unsubscribe")
         }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -107,11 +107,10 @@ open class Store<State: StateType>: StoreType {
     open func _defaultDispatch(action: Action) {
         guard !isDispatching else {
             raiseFatalError(
-                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: " +
-                " A reducer is dispatching an action," +
-                " multiple GCD queues are dispatching/subscribing to a single store," +
-                " or a concurrent GCD queue (such as global()) is being used to" +
-                " dispatch/subscribe/unsubscribe")
+                "ReSwift:ConcurrentMutationError- Action has been dispatched while" +
+                " a previous action is action is being processed. A reducer" +
+                " is dispatching an action, or ReSwift is used in a concurrent context" +
+                " (e.g. from multiple threads)."
         }
 
         isDispatching = true

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -107,7 +107,7 @@ open class Store<State: StateType>: StoreType {
     open func _defaultDispatch(action: Action) -> Void {
         guard !isDispatching else {
             raiseFatalError(
-                "ReSwift:IllegalDispatchFromReducer - Reducers may not dispatch actions.")
+                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: A reducer is dispatching an action, multiple GCD queues are dispatching/subscribing to a single store, or a concurrent GCD queue (such as global()) is being dispatched/subscribed/unsubscribed to")
         }
 
         isDispatching = true

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -107,7 +107,11 @@ open class Store<State: StateType>: StoreType {
     open func _defaultDispatch(action: Action) -> Void {
         guard !isDispatching else {
             raiseFatalError(
-                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: A reducer is dispatching an action, multiple GCD queues are dispatching/subscribing to a single store, or a concurrent GCD queue (such as global()) is being dispatched/subscribed/unsubscribed to")
+                "ReSwift:ConcurrentMutationError- Concurrent mutation detected. Possible causes: " + 
+                " A reducer is dispatching an action," +
+                " multiple GCD queues are dispatching/subscribing to a single store," + 
+                " or a concurrent GCD queue (such as global()) is being used to" +
+                " dispatch/subscribe/unsubscribe")
         }
 
         isDispatching = true


### PR DESCRIPTION
The documentation here is not an academic issue. Not only did I spend several days of time hunting down issues around this, several other iOS programmers on the iOS programming slack immediately came to the same conclusions I originally had that it was permissible to dispatch from a concurrent dispatch queue. 

Many *other* programmers probably don't *know* the global() background queue is concurrent, nor do they currently understand their queue choice is what causes the error as currently written in the codebase.

This PR hopefully adds enough prohibitions to the documentation as well as changes the dispatch exception to a more general, concurrency based exception, thereby letting future programmers understand what is wrong with their code and concurrency strategy.