### PR TITLE
Opt-in Equatable State

### DIFF
--- a/ReSwift/CoreTypes/State.swift
+++ b/ReSwift/CoreTypes/State.swift
@@ -9,3 +9,13 @@
 import Foundation
 
 public protocol StateType { }
+
+public protocol EquatableState {
+    func isEqualState(to state: Self) -> Bool
+}
+
+public extension EquatableState where Self: Equatable {
+    public func isEqualState(to state: Self) -> Bool {
+        return self == state
+    }
+}

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -17,8 +17,6 @@ import Foundation
  */
 open class Store<State: StateType>: StoreType {
 
-    typealias SubscriptionType = Subscription<State>
-
     // swiftlint:disable todo
     // TODO: Setter should not be public; need way for store enhancers to modify appState anyway
 
@@ -28,7 +26,7 @@ open class Store<State: StateType>: StoreType {
             subscriptions.forEach {
                 // if a selector is available, subselect the relevant state
                 // otherwise pass the entire state to the subscriber
-                $0.subscriber?._newState(state: $0.selector?(state) ?? state)
+                $0.newState(state: state, oldState: oldValue)
             }
         }
     }
@@ -37,7 +35,7 @@ open class Store<State: StateType>: StoreType {
 
     private var reducer: Reducer<State>
 
-    var subscriptions: [SubscriptionType] = []
+    var subscriptions: [AnySubscription] = []
 
     private var isDispatching = false
 
@@ -91,10 +89,43 @@ open class Store<State: StateType>: StoreType {
         where S.StoreSubscriberStateType == SelectedState {
             if !_isNewSubscriber(subscriber: subscriber) { return }
 
-            subscriptions.append(Subscription(subscriber: subscriber, selector: selector))
+            let subscription = Subscription(subscriber: subscriber, selector: selector)
+            subscriptions.append(subscription)
 
             if let state = self.state {
-                subscriber._newState(state: selector?(state) ?? state)
+                subscription.newState(state: state, oldState: nil)
+            }
+    }
+
+    open func subscribe<SelectedState: Equatable, S: StoreSubscriber>
+        (_ subscriber: S, selector: ((State) -> SelectedState)?)
+        where S.StoreSubscriberStateType == SelectedState {
+            if !_isNewSubscriber(subscriber: subscriber) { return }
+
+            let subscription = EquatableSubscription(
+                subscriber: subscriber,
+                selector: selector
+            )
+            subscriptions.append(subscription)
+
+            if let state = self.state {
+                subscription.newState(state: state, oldState: nil)
+            }
+    }
+
+    open func subscribe<SelectedState: Equatable, S: StoreSubscriber>
+        (_ subscriber: S, selector: ((State) -> SelectedState?)?)
+        where S.StoreSubscriberStateType == SelectedState? {
+            if !_isNewSubscriber(subscriber: subscriber) { return }
+
+            let subscription = OptionalEquatableSubscription(
+                subscriber: subscriber,
+                selector: selector
+            )
+            subscriptions.append(subscription)
+
+            if let state = self.state {
+                subscription.newState(state: state, oldState: nil)
             }
     }
 
@@ -154,4 +185,11 @@ open class Store<State: StateType>: StoreType {
         _ store: Store,
         _ actionCreatorCallback: @escaping ((ActionCreator) -> Void)
     ) -> Void
+}
+
+extension Store where State: Equatable {
+    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
+        where State: Equatable, S.StoreSubscriberStateType == State {
+            subscribe(subscriber, selector: nil)
+    }
 }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -188,7 +188,7 @@ open class Store<State: StateType>: StoreType {
 
 extension Store where State: EquatableState {
     open func subscribe<S: StoreSubscriber>(_ subscriber: S)
-        where State: EquatableState, S.StoreSubscriberStateType == State {
+        where S.StoreSubscriberStateType == State {
             subscribe(subscriber, selector: nil)
     }
 }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -97,7 +97,7 @@ open class Store<State: StateType>: StoreType {
             }
     }
 
-    open func subscribe<SelectedState: Equatable, S: StoreSubscriber>
+    open func subscribe<SelectedState: EquatableState, S: StoreSubscriber>
         (_ subscriber: S, selector: ((State) -> SelectedState)?)
         where S.StoreSubscriberStateType == SelectedState {
             if !_isNewSubscriber(subscriber: subscriber) { return }
@@ -113,7 +113,7 @@ open class Store<State: StateType>: StoreType {
             }
     }
 
-    open func subscribe<SelectedState: Equatable, S: StoreSubscriber>
+    open func subscribe<SelectedState: EquatableState, S: StoreSubscriber>
         (_ subscriber: S, selector: ((State) -> SelectedState?)?)
         where S.StoreSubscriberStateType == SelectedState? {
             if !_isNewSubscriber(subscriber: subscriber) { return }
@@ -187,9 +187,9 @@ open class Store<State: StateType>: StoreType {
     ) -> Void
 }
 
-extension Store where State: Equatable {
+extension Store where State: EquatableState {
     open func subscribe<S: StoreSubscriber>(_ subscriber: S)
-        where State: Equatable, S.StoreSubscriberStateType == State {
+        where State: EquatableState, S.StoreSubscriberStateType == State {
             subscribe(subscriber, selector: nil)
     }
 }

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 public protocol AnyStoreSubscriber: class {
-    func _newState(state: Any)
+    func _newState<T: Any>(state: T, oldState: T?)
+    func _newEquatableState<T: Equatable>(state: T, oldState: T?)
+    func _newOptionalEquatableState<T: Equatable>(state: T?, oldState: T??)
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {
@@ -19,7 +21,29 @@ public protocol StoreSubscriber: AnyStoreSubscriber {
 }
 
 extension StoreSubscriber {
-    public func _newState(state: Any) {
+    public func _newState<T: Any>(state: T, oldState: T? = nil) {
+        if let typedState = state as? StoreSubscriberStateType {
+            newState(state: typedState)
+        }
+    }
+
+    public func _newEquatableState<T: Equatable>(state: T, oldState: T?) {
+        if let oldState = oldState,
+            state == oldState {
+            return
+        }
+
+        if let typedState = state as? StoreSubscriberStateType {
+            newState(state: typedState)
+        }
+    }
+
+    public func _newOptionalEquatableState<T: Equatable>(state: T?, oldState: T??) {
+        if let oldState = oldState,
+            state == oldState {
+            return
+        }
+
         if let typedState = state as? StoreSubscriberStateType {
             newState(state: typedState)
         }

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -8,7 +8,76 @@
 
 import Foundation
 
-struct Subscription<State: StateType> {
+protocol AnySubscription {
+    var subscriber: AnyStoreSubscriber? { get }
+    func newState<T: StateType>(state: T, oldState: T?)
+}
+
+struct Subscription<State: StateType, SelectedState> {
     private(set) weak var subscriber: AnyStoreSubscriber? = nil
-    let selector: ((State) -> Any)?
+    let selector: ((State) -> SelectedState)?
+
+    func newState(state: State, oldState: State?) {
+        if let selector = selector {
+            subscriber?._newState(state: selector(state), oldState: oldState.map(selector))
+        } else if let state = state as? SelectedState {
+            subscriber?._newState(state: state, oldState: oldState as? SelectedState)
+        }
+    }
+}
+
+struct EquatableSubscription<State: StateType, SelectedState: Equatable> {
+    private(set) weak var subscriber: AnyStoreSubscriber? = nil
+    let selector: ((State) -> SelectedState)?
+
+    func newState(state: State, oldState: State?) {
+        if let selector = selector {
+            subscriber?._newEquatableState(state: selector(state), oldState: oldState.map(selector))
+        } else if let state = state as? SelectedState {
+            subscriber?._newEquatableState(state: state, oldState: oldState as? SelectedState)
+        }
+    }
+}
+
+struct OptionalEquatableSubscription<State: StateType, SelectedState: Equatable> {
+    private(set) weak var subscriber: AnyStoreSubscriber? = nil
+    let selector: ((State) -> SelectedState?)?
+
+    func newState(state: State, oldState: State?) {
+        if let selector = selector {
+            subscriber?._newOptionalEquatableState(
+                state: selector(state),
+                oldState: oldState.map(selector)
+            )
+        } else {
+            fatalError("Impossible to have optional base state")
+        }
+    }
+}
+
+extension Subscription: AnySubscription {
+    func newState<T: StateType>(state: T, oldState: T?) {
+        if let state = state as? State {
+            let oldState = oldState as? State
+            newState(state: state, oldState: oldState)
+        }
+    }
+}
+
+extension EquatableSubscription: AnySubscription {
+    func newState<T: StateType>(state: T, oldState: T?) {
+        if let state = state as? State {
+            let oldState = oldState as? State
+            newState(state: state, oldState: oldState)
+        }
+    }
+}
+
+extension OptionalEquatableSubscription: AnySubscription {
+    func newState<T: StateType>(state: T, oldState: T?) {
+        if let state = state as? State {
+            let oldState = oldState as? State
+            newState(state: state, oldState: oldState)
+        }
+    }
 }

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -26,7 +26,7 @@ struct Subscription<State: StateType, SelectedState> {
     }
 }
 
-struct EquatableSubscription<State: StateType, SelectedState: Equatable> {
+struct EquatableSubscription<State: StateType, SelectedState: EquatableState> {
     private(set) weak var subscriber: AnyStoreSubscriber? = nil
     let selector: ((State) -> SelectedState)?
 
@@ -39,7 +39,7 @@ struct EquatableSubscription<State: StateType, SelectedState: Equatable> {
     }
 }
 
-struct OptionalEquatableSubscription<State: StateType, SelectedState: Equatable> {
+struct OptionalEquatableSubscription<State: StateType, SelectedState: EquatableState> {
     private(set) weak var subscriber: AnyStoreSubscriber? = nil
     let selector: ((State) -> SelectedState?)?
 

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -44,13 +44,37 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.receivedValue.0, 5)
         XCTAssertEqual(subscriber.receivedValue.1, "TestName")
     }
+
+    /**
+     it does not notify subscriber for unchanged equatable state
+     */
+    func testUnchangedStateSelector() {
+        let reducer = TestReducer()
+        var state = TestAppState()
+        state.testValue = 3
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber()
+
+        store.subscribe(subscriber) {
+            $0.testValue
+        }
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
 }
 
 class TestFilteredSubscriber: StoreSubscriber {
     var receivedValue: Int?
+    var newStateCallCount: Int = 0
 
     func newState(state: Int?) {
         receivedValue = state
+        newStateCallCount += 1
     }
 
 }

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -66,6 +66,28 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.receivedValue, 3)
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
+
+    /**
+     it does not notify subscriber for unchanged equatable state
+     */
+    func testUnchangedNonOptionalStateSelector() {
+        let reducer = TestReducer()
+        var state = TestAppState()
+        state.otherTestValue = 3
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredNonOptionalSubscriber()
+
+        store.subscribe(subscriber) {
+            $0.otherTestValue
+        }
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
 }
 
 class TestFilteredSubscriber: StoreSubscriber {
@@ -76,7 +98,16 @@ class TestFilteredSubscriber: StoreSubscriber {
         receivedValue = state
         newStateCallCount += 1
     }
+}
 
+class TestFilteredNonOptionalSubscriber: StoreSubscriber {
+    var receivedValue: Int?
+    var newStateCallCount: Int = 0
+
+    func newState(state: Int) {
+        receivedValue = state
+        newStateCallCount += 1
+    }
 }
 
 /**

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -82,6 +82,7 @@ class StoreSubscriberTests: XCTestCase {
         }
 
         XCTAssertEqual(subscriber.receivedValue, 3)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
 
         store.dispatch(SetValueAction(3))
 

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -91,6 +91,23 @@ class StoreSubscriptionTests: XCTestCase {
     }
 
     /**
+     it does not notify subscriber for unchanged equatable state
+     */
+    func testDontNotifyForUnchangedState() {
+        let reducer = TestEquatableReducer()
+
+        var state = TestEquatableAppState()
+        state.testValue = 2
+        let store = Store<TestEquatableAppState>(reducer: reducer.handleAction, state: state)
+        let subscriber = TestStoreSubscriber<TestEquatableAppState>()
+
+        store.subscribe(subscriber)
+        store.dispatch(SetValueAction(2))
+
+        XCTAssertEqual(subscriber.receivedStates.count, 1)
+    }
+
+    /**
      it does not dispatch value after subscriber unsubscribes
      */
     func testDontDispatchToUnsubscribers() {

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -9,6 +9,8 @@
 import Foundation
 import ReSwift
 
+extension Int: EquatableState {}
+
 struct TestAppState: StateType {
     var testValue: Int?
     var otherTestValue: Int = 0
@@ -26,7 +28,7 @@ struct TestStringAppState: StateType {
     }
 }
 
-struct TestEquatableAppState: StateType, Equatable {
+struct TestEquatableAppState: StateType, EquatableState, Equatable {
     var testValue: Int?
 
     init() {

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -11,6 +11,7 @@ import ReSwift
 
 struct TestAppState: StateType {
     var testValue: Int?
+    var otherTestValue: Int = 0
 
     init() {
         testValue = nil

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -25,6 +25,18 @@ struct TestStringAppState: StateType {
     }
 }
 
+struct TestEquatableAppState: StateType, Equatable {
+    var testValue: Int?
+
+    init() {
+        testValue = nil
+    }
+
+    static func == (left: TestEquatableAppState, right: TestEquatableAppState) -> Bool {
+        return left.testValue == right.testValue
+    }
+}
+
 struct SetValueAction: StandardActionConvertible {
 
     let value: Int
@@ -69,6 +81,20 @@ struct SetValueStringAction: StandardActionConvertible {
 struct TestReducer {
     func handleAction(action: Action, state: TestAppState?) -> TestAppState {
         var state = state ?? TestAppState()
+
+        switch action {
+        case let action as SetValueAction:
+            state.testValue = action.value
+            return state
+        default:
+            return state
+        }
+    }
+}
+
+struct TestEquatableReducer {
+    func handleAction(action: Action, state: TestEquatableAppState?) -> TestEquatableAppState {
+        var state = state ?? TestEquatableAppState()
 
         switch action {
         case let action as SetValueAction:


### PR DESCRIPTION
This allows users to opt-in to state (or any substate) being Equatable.
This causes `newState` to not be called if the selected state is `Equatable` & unchanged.

I chose to go opt-in since it has the least impact on existing users. If we wanted to make it requred, instead, It is a relatively easy change from here, by making `StateType: Equatable`, and `SelectedState: Equatable` for all `subscribe` functions.

This change is mostly backwards compatible, with no code changes necessary for existing users. The only difference is users who already have been selecting an `Equatable` sub-state will find `newState` not being called as often.

There is a performance implication here since comparisons are made each time the store changes, which can be reduced by using subscription selectors to select the minimum necessary state. (which reduces the equality checks required.)

Fixes #176

TODO:
- [ ] Documentation