### PR TITLE
Add subscriber with substate selector to StoreType

### DIFF
--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -44,6 +44,18 @@ public protocol StoreType {
     func subscribe<S: StoreSubscriber>(_ subscriber: S) where S.StoreSubscriberStateType == State
 
     /**
+     Subscribes the provided subscriber to this store.
+     Subscribers will receive a call to `newState` whenever the
+     state in this store changes.
+
+     - parameter subscriber: Subscriber that will receive store updates
+     - parameter selector: A selector for the sub-state the subscriber will receive
+     */
+    func subscribe<SelectedState, S: StoreSubscriber>
+        (_ subscriber: S, selector: ((State) -> SelectedState)?)
+    where S.StoreSubscriberStateType == SelectedState
+
+    /**
      Unsubscribes the provided subscriber. The subscriber will no longer
      receive state updates from this store.
 


### PR DESCRIPTION
Allows use of StoreType for generic classes which use substate selection, without the creation of a separate protocol.