### PR TITLE
Remove convenience init and replace with default value for middleware

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -41,14 +41,10 @@ open class Store<State: StateType>: StoreType {
 
     private var isDispatching = false
 
-    public required convenience init(reducer: @escaping Reducer<State>, state: State?) {
-        self.init(reducer: reducer, state: state, middleware: [])
-    }
-
     public required init(
         reducer: @escaping Reducer<State>,
         state: State?,
-        middleware: [Middleware]
+        middleware: [Middleware] = []
     ) {
         self.reducer = reducer
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -18,9 +18,6 @@ public protocol StoreType {
 
     associatedtype State: StateType
 
-    /// Initializes the store with a reducer and an intial state.
-    init(reducer: @escaping Reducer<State>, state: State?)
-
     /// Initializes the store with a reducer, an initial state and a list of middleware.
     /// Middleware is applied in the order in which it is passed into this constructor.
     init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware])


### PR DESCRIPTION
Since the convenience init only set the Middleware for us, we can replace this with a default value of `[]` and have the Swift compiler auto-generate a convenience init for us.