### PR TITLE
Fix build failure when used with SwiftLint 0.16.1

### DIFF
--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -14,7 +14,7 @@ let firstMiddleware: Middleware = { dispatch, getState in
         return { action in
 
             if var action = action as? SetValueStringAction {
-                action.value = action.value + " First Middleware"
+                action.value += " First Middleware"
                 return next(action)
             } else {
                 return next(action)
@@ -28,7 +28,7 @@ let secondMiddleware: Middleware = { dispatch, getState in
         return { action in
 
             if var action = action as? SetValueStringAction {
-                action.value = action.value + " Second Middleware"
+                action.value += " Second Middleware"
                 return next(action)
             } else {
                 return next(action)


### PR DESCRIPTION
Today I noticed that when building on a machine with SwiftLint 0.16.1 the build fails. This is due to a new SwiftLint rule, shorthand_operator, which has been introduced in version 0.16.1.

This PR updates the code to be complaint with that rule. It simply replaces `let foo = foo + bar` with `let foo += bar`.

An alternative to this option is to disable the rule in the `.swiftlint.yml` config file. I'm happy to close this and submit a new one if that's the preferred style 😄 .

My suggestion is to keep it enabled, as it makes the code more succinct.