### PR TITLE
Remove conditional_binding_cascade rule from SwiftLint config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,4 +4,3 @@ excluded: # paths to ignore during linting. overridden by `included`.
 
 disabled_rules: # rule identifiers to exclude from running
   - force_cast
-  - conditional_binding_cascade


### PR DESCRIPTION
This rule has been removed from SwiftLint by [this PR](https://github.com/realm/SwiftLint/issues/701).

When running SwiftLint version 0.16.1 with a config file that disables this rule we endup with this outpus

```
$ swiftlint
Loading configuration from '.swiftlint.yml'
configuration error: 'conditional_binding_cascade' is not a valid rule identifier
Valid rule identifiers:
[...] a list of all the valid rules
```

This warning doesn't prevent the linting from running, and doesn't break the Xcode integration. As every warning though it should be looked at and addressed.