### PR TITLE
Skip Repeats Implementation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,4 @@ excluded: # paths to ignore during linting. overridden by `included`.
 
 disabled_rules: # rule identifiers to exclude from running
   - force_cast
+  - opening_brace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,44 @@
-#Upcoming Release
+#4.0.0
+
+*Work in Progress*
+
+**Breaking API Changes:**
+
+- Introduced a new Subscription API (#203) - @Ben-G
+
+  - The subscription API provides basic operators, such as `skipRepeats` (skip calls to `newState` unless state value changed) and `select` (sub-select a state).
+
+  - This is a breaking API change that requires migrating existing subscriptions that sub-select a portion of a store's state:
+
+    - Subselecting state in 3.0.0:
+
+      ```swift
+      store.subscribe(subscriber) { ($0.testValue, $0.otherState?.name) }
+      ```
+    - Subselecting state in 4.0.0:
+
+      ```swift
+      store.subscribe(subscriber) {
+        $0.select {
+          ($0.testValue, $0.otherState?.name)
+        }
+      }
+      ```
+
+  - For any store state that is `Equatable` or any sub-selected state that is `Equatable`, `skipRepeats` will be used by default.
+
+  - For states/substates that are not `Equatable`, `skipRepeats` can be implemented via a closure:
+
+    ```swift
+    store.subscribe(subscriber) {
+      $0.select {
+          $0.testValue
+          }.skipRepeats {
+              return $0 == $1
+          }
+    }
+    ```
+
 
 #3.0.0
 *Released: 11/12/2016*

--- a/ReSwift/CoreTypes/DispatchingStoreType.swift
+++ b/ReSwift/CoreTypes/DispatchingStoreType.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /**
- Defines the interface of a dispatching, stateless Store in ReSwift. `StoreType` is 
+ Defines the interface of a dispatching, stateless Store in ReSwift. `StoreType` is
  the default usage of this interface. Can be used for store variables where you don't
  care about the state, but want to be able to dispatch actions.
  */

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -165,3 +165,12 @@ open class Store<State: StateType>: StoreType {
         _ actionCreatorCallback: @escaping ((ActionCreator) -> Void)
     ) -> Void
 }
+
+// MARK: Skip Repeats for Equatable States
+
+extension Store where State: Equatable {
+    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
+        where S.StoreSubscriberStateType == State {
+            _ = subscribe(subscriber, transform: { $0.skipRepeats() })
+    }
+}

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -43,14 +43,17 @@ public protocol StoreType: DispatchingStoreType {
     /**
      Subscribes the provided subscriber to this store.
      Subscribers will receive a call to `newState` whenever the
-     state in this store changes.
+     state in this store changes and the subscription decides to forward
+     state update.
 
      - parameter subscriber: Subscriber that will receive store updates
-     - parameter selector: A selector for the sub-state the subscriber will receive
+     - parameter transform: A closure that receives a simple subscription and can return a
+       transformed subscription. Subscriptions can be transformed to only select a subset of the
+       state, or to skip certain state updates.
      */
-    func subscribe<SelectedState, S: StoreSubscriber>
-        (_ subscriber: S, selector: ((State) -> SelectedState)?)
-    where S.StoreSubscriberStateType == SelectedState
+    func subscribe<SelectedState, S: StoreSubscriber>(
+        _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?
+    ) where S.StoreSubscriberStateType == SelectedState
 
     /**
      Unsubscribes the provided subscriber. The subscriber will no longer

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A box arounds subscriptions and subscribers.
+/// A box around subscriptions and subscribers.
 ///
 /// Acts as a type-erasing wrapper around a subscription and its transformed subscription.
 /// The transformed subscription has a type argument that matches the selected substate of the

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -8,7 +8,121 @@
 
 import Foundation
 
-struct Subscription<State: StateType> {
-    private(set) weak var subscriber: AnyStoreSubscriber?
-    let selector: ((State) -> Any)?
+/// A box arounds subscriptions and subscribers.
+///
+/// Acts as a type-erasing wrapper around a subscription and its transformed subscription.
+/// The transformed subscription has a type argument that matches the selected substate of the
+/// subscriber; however that type cannot be exposed to the store.
+///
+/// The box subscribes either to the original subscription, or if available to the transformed
+/// subscription and passes any values that come through this subscriptions to the subscriber.
+class SubscriptionBox<State> {
+
+    private let originalSubscription: Subscription<State>
+    weak var subscriber: AnyStoreSubscriber?
+
+    init<T>(
+        originalSubscription: Subscription<State>,
+        transformedSubscription: Subscription<T>?,
+        subscriber: AnyStoreSubscriber
+    ) {
+        self.originalSubscription = originalSubscription
+        self.subscriber = subscriber
+
+        // If we received a transformed subscription, we subscribe to that subscription
+        // and forward all new values to the subscriber.
+        if let transformedSubscription = transformedSubscription {
+            transformedSubscription.observe { oldState, newState in
+                self.subscriber?._newState(state: newState as Any)
+            }
+        // If we haven't received a transformed subscription, we forward all values
+        // from the original subscription.
+        } else {
+            originalSubscription.observe { oldState, newState in
+                self.subscriber?._newState(state: newState as Any)
+            }
+        }
+    }
+
+    func newValues(oldState: State, newState: State) {
+        // We pass all new values through the original subscription, which accepts
+        // values of type `<State>`. If present, transformed subscriptions will
+        // receive this update and transform it before passing it on to the subscriber.
+        self.originalSubscription.newValues(oldState: oldState, newState: newState)
+    }
+}
+
+/// Represents a subscription of a subscriber to the store. The subscription determines which new
+/// values from the store are forwarded to the subscriber, and how they are transformed.
+/// The subscription acts as a very-light weight signal/observable that you might know from
+/// reactive programming libraries.
+public class Subscription<State> {
+
+    // MARK: Public Interface
+
+    /// Provides a subscription that selects a substate of the state of the original subscription.
+    /// - parameter selector: A closure that maps a state to a selected substate
+    public func select<Substate>(
+        _ selector: @escaping (State) -> Substate
+        ) -> Subscription<Substate>
+    {
+        return Subscription<Substate> { sink in
+            self.observe { oldState, newState in
+                sink(oldState.map(selector) ?? nil, newState.map(selector) ?? nil)
+            }
+        }
+    }
+
+    /// Provides a subscription that skips certain state updates of the original subscription.
+    /// - parameter isRepeat: A closure that determines whether a given state update is a repeat and
+    /// thus should be skipped and not forwarded to subscribers.
+    public func skipRepeats(_ isRepeat: @escaping (State, State) -> Bool) -> Subscription<State> {
+        return Subscription<State> { sink in
+            self.observe { oldState, newState in
+                switch (oldState, newState) {
+                case let (old?, new?):
+                    if !isRepeat(old, new) {
+                        sink(oldState, newState)
+                    } else {
+                        return
+                    }
+                default:
+                    sink(oldState, newState)
+                }
+            }
+        }
+    }
+
+    // MARK: Internals
+
+    var observer: ((State?, State?) -> Void)? = nil
+
+    init() {}
+
+    /// Initializes a subscription with a sink closure. The closure provides a way to send
+    /// new values over this subscription.
+    private init(sink: @escaping (@escaping (State?, State?) -> Void) -> Void) {
+        // Provide the caller with a closure that will forward all values
+        // to observers of this subscription.
+        sink { old, new in
+            self.newValues(oldState: old, newState: new)
+        }
+    }
+
+    /// Sends new values over this subscription. Observers will be notified of these new values.
+    func newValues(oldState: State?, newState: State?) {
+        self.observer?(oldState, newState)
+    }
+
+    /// A caller can observe new values of this subscription through the provided closure.
+    /// - Note: subscriptions only support a single observer.
+    fileprivate func observe(observer: @escaping (State?, State?) -> Void) {
+        self.observer = observer
+    }
+}
+
+extension Subscription where State: Equatable {
+    public func skipRepeats() -> Subscription<State>{
+        return self.skipRepeats(==)
+    }
 }

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -58,11 +58,7 @@ class SubscriptionBox<State> {
 /// reactive programming libraries.
 public class Subscription<State> {
 
-    // MARK: Public Interface
-
-    /// Provides a subscription that selects a substate of the state of the original subscription.
-    /// - parameter selector: A closure that maps a state to a selected substate
-    public func select<Substate>(
+    private func _select<Substate>(
         _ selector: @escaping (State) -> Substate
         ) -> Subscription<Substate>
     {
@@ -71,6 +67,27 @@ public class Subscription<State> {
                 sink(oldState.map(selector) ?? nil, newState.map(selector) ?? nil)
             }
         }
+    }
+
+    // MARK: Public Interface
+
+    /// Provides a subscription that selects a substate of the state of the original subscription.
+    /// - parameter selector: A closure that maps a state to a selected substate
+    public func select<Substate>(
+        _ selector: @escaping (State) -> Substate
+        ) -> Subscription<Substate>
+    {
+        return self._select(selector)
+    }
+
+    /// Provides a subscription that selects a substate of the state of the original subscription.
+    /// If the selected substate is `Equatable` repeated state updates will be skipped.
+    /// - parameter selector: A closure that maps a state to a selected substate
+    public func select<Substate: Equatable>(
+        _ selector: @escaping (State) -> Substate
+        ) -> Subscription<Substate>
+    {
+        return self._select(selector).skipRepeats()
     }
 
     /// Provides a subscription that skips certain state updates of the original subscription.

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -98,6 +98,27 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
+    /**
+     it skips repeated state values by default when the selected substate is `Equatable`.
+     */
+    func testSkipsStateUpdatesForEquatableSubstatesByDefault() {
+        let reducer = TestValueStringReducer()
+        let state = TestStringAppState()
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<String>()
+
+        store.subscribe(subscriber) {
+            $0.select { $0.testValue }
+        }
+
+        XCTAssertEqual(subscriber.receivedValue, "Initial")
+
+        store.dispatch(SetValueStringAction("Initial"))
+
+        XCTAssertEqual(subscriber.receivedValue, "Initial")
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
+
 }
 
 class TestFilteredSubscriber<T>: StoreSubscriber {

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -99,6 +99,28 @@ class StoreSubscriberTests: XCTestCase {
     }
 
     /**
+     it skips repeated state values by when `skipRepeats` returns `true`.
+     */
+    func testSkipsStateUpdatesForCustomEqualityChecks() {
+        let reducer = TestCustomAppStateReducer()
+        let state = TestCustomAppState(substateValue: 5)
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
+
+        store.subscribe(subscriber) {
+            $0.select { $0.substate }
+                .skipRepeats { $0.value == $1.value }
+        }
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+
+        store.dispatch(SetCustomSubstateAction(5))
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
+
+    /**
      it skips repeated state values by default when the selected substate is `Equatable`.
      */
     func testSkipsStateUpdatesForEquatableSubstatesByDefault() {

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -141,6 +141,22 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
+    func testSkipsStateUpdatesForEquatableStateByDefault() {
+        let reducer = TestValueStringReducer()
+        let state = TestStringAppState()
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<TestStringAppState>()
+
+        store.subscribe(subscriber)
+
+        XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
+
+        store.dispatch(SetValueStringAction("Initial"))
+
+        XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
+
 }
 
 class TestFilteredSubscriber<T>: StoreSubscriber {

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -25,6 +25,12 @@ struct TestStringAppState: StateType {
     }
 }
 
+extension TestStringAppState: Equatable {
+    static func == (lhs: TestStringAppState, rhs: TestStringAppState) -> Bool {
+        return lhs.testValue == rhs.testValue
+    }
+}
+
 struct TestCustomAppState: StateType {
     var substate: TestCustomSubstate
 

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -25,6 +25,22 @@ struct TestStringAppState: StateType {
     }
 }
 
+struct TestCustomAppState: StateType {
+    var substate: TestCustomSubstate
+
+    init(substate: TestCustomSubstate) {
+        self.substate = substate
+    }
+
+    init(substateValue value: Int = 0) {
+        self.substate = TestCustomSubstate(value: value)
+    }
+
+    struct TestCustomSubstate {
+        var value: Int
+    }
+}
+
 struct SetValueAction: StandardActionConvertible {
 
     let value: Int
@@ -66,6 +82,26 @@ struct SetValueStringAction: StandardActionConvertible {
 
 }
 
+struct SetCustomSubstateAction: StandardActionConvertible {
+
+    var value: Int
+    static let type = "SetCustomSubstateAction"
+
+    init (_ value: Int) {
+        self.value = value
+    }
+
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! Int
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueStringAction.type,
+                              payload: ["value": value as AnyObject],
+                              isTypedAction: true)
+    }
+}
+
 struct TestReducer {
     func handleAction(action: Action, state: TestAppState?) -> TestAppState {
         var state = state ?? TestAppState()
@@ -87,6 +123,20 @@ struct TestValueStringReducer {
         switch action {
         case let action as SetValueStringAction:
             state.testValue = action.value
+            return state
+        default:
+            return state
+        }
+    }
+}
+
+struct TestCustomAppStateReducer {
+    func handleAction(action: Action, state: TestCustomAppState?) -> TestCustomAppState {
+        var state = state ?? TestCustomAppState()
+
+        switch action {
+        case let action as SetCustomSubstateAction:
+            state.substate.value = action.value
             return state
         default:
             return state

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -18,10 +18,10 @@ struct TestAppState: StateType {
 }
 
 struct TestStringAppState: StateType {
-    var testValue: String?
+    var testValue: String
 
     init() {
-        testValue = nil
+        testValue = "Initial"
     }
 }
 


### PR DESCRIPTION
Thanks a lot to @mjarvis and his work in #190. As part of reviewing his change I noticed some of the aspects that I think could be improved. It would be nice to add a feature that allows skipping state updates that haven't changed a certain substate to the core of ReSwift, as a lot of folks have been asking about that.

However, after some prototyping, I think that the implementation of this should live in the subscription and not in the store. Looking at this prototype, the changes become a lot less invasive that way.

Essentially our subscription type is very, very lightweight reactive component that transforms new values coming out of the store. By keeping the logic in the subscription, we make that reactive component extensible, independent of the rest of ReSwift.  We can add a few operators to it (such as `skipRepeats`) that are going to be used by a majority of developers (however, we should refrain from implementing a full signal library, since enough great libraries exist in that space).

The implementation right now is still pretty hard-wired. I would like to improve this, such that all the transformation logic of new values lives in the subscription and such that various transformations can be composed (as in reactive libraries).

But since I'm almost out of time for this weekend, I wanted to share this working prototype for now.

-----

## To-do list

(by @DivineDominion: Just to end up in the PR overview, I pulled the comments here as a todo)


- [ ] Provide alternative API for creating a subscription that doesn't require using a closure
- [x] Make equatable substates use `skipRepeats` by default
- [ ] Potentially find a new name for `Subscription`/`skipRepeats`, though I haven't heard suggestions on this yet. 
- [ ] document subscription API change:

>         // If the same subscriber is already registered with the store, replace the existing
>         // subscription with the new one.
>         if let index = subscriptions.index(where: { $0.subscriber === subscriber }) {
