### PR TITLE
Suppress Xcode 8.3 warning

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -28,6 +28,11 @@ open class Store<State: StateType>: StoreType {
             subscriptions.forEach {
                 // if a selector is available, subselect the relevant state
                 // otherwise pass the entire state to the subscriber
+                guard let state = state else {
+                    // State should never be nil after `ReSwiftInit`
+                    preconditionFailure("Unexpectedly found `nil` while unwrapping state")
+                }
+
                 $0.subscriber?._newState(state: $0.selector?(state) ?? state)
             }
         }
@@ -112,12 +117,10 @@ open class Store<State: StateType>: StoreType {
         state = newState
     }
 
-    @discardableResult
     open func dispatch(_ action: Action) -> Void {
         dispatchFunction(action)
     }
 
-    @discardableResult
     open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) -> Void {
         if let action = actionCreatorProvider(state, self) {
             dispatch(action)


### PR DESCRIPTION
Compiler warns `Expression implicitly coerced from ‘Any?’ to Any`
We’re safe to force unwrap this (as the variable definition is force unwrapped in the first place)