### PR TITLE
remove single param subscribe func 

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -76,13 +76,8 @@ open class Store<State: StateType>: StoreType {
         return true
     }
 
-    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
-        where S.StoreSubscriberStateType == State {
-            subscribe(subscriber, selector: nil)
-    }
-
     open func subscribe<SelectedState, S: StoreSubscriber>
-        (_ subscriber: S, selector: ((State) -> SelectedState)?)
+        (_ subscriber: S, selector: ((State) -> SelectedState)? = nil)
         where S.StoreSubscriberStateType == SelectedState {
             if !_isNewSubscriber(subscriber: subscriber) { return }
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -37,15 +37,6 @@ public protocol StoreType: DispatchingStoreType {
      state in this store changes.
 
      - parameter subscriber: Subscriber that will receive store updates
-     */
-    func subscribe<S: StoreSubscriber>(_ subscriber: S) where S.StoreSubscriberStateType == State
-
-    /**
-     Subscribes the provided subscriber to this store.
-     Subscribers will receive a call to `newState` whenever the
-     state in this store changes.
-
-     - parameter subscriber: Subscriber that will receive store updates
      - parameter selector: A selector for the sub-state the subscriber will receive
      */
     func subscribe<SelectedState, S: StoreSubscriber>


### PR DESCRIPTION
Remove single parameter `subscribe` function and replace it with a default `nil` selector parameter.