### PR TITLE
Revert nullable return for Reducer from 907e2f6

### DIFF
--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 public typealias Reducer<ReducerStateType> =
-    (_ action: Action, _ state: ReducerStateType?) -> ReducerStateType?
+    (_ action: Action, _ state: ReducerStateType?) -> ReducerStateType


### PR DESCRIPTION
The Store's state should never be nil after `ReSwiftInit`. Allowing a reducer to return nil contradicts that, and goes against the interface of the store which declares `var state: State!`.

Since this code was never released we can safely revert this change without breaking backwards compatibility.

Based on the conversation from https://github.com/ReSwift/ReSwift/pull/205#discussion_r101688570