### PR TITLE
Replace optional DispatchFunction Middleware by plain DispatchFunction

### DIFF
--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -11,4 +11,4 @@ import Foundation
 public typealias DispatchFunction = (Action) -> Void
 public typealias GetState = () -> StateType?
 public typealias Middleware =
-    (DispatchFunction?, @escaping GetState) -> (@escaping DispatchFunction) -> DispatchFunction
+    (@escaping DispatchFunction, @escaping GetState) -> (@escaping DispatchFunction) -> DispatchFunction

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -50,11 +50,10 @@ open class Store<State: StateType>: StoreType {
         // Wrap the dispatch function with all middlewares
         self.dispatchFunction = middleware
             .reversed()
-            .reduce({ [unowned self] action in
-                return self._defaultDispatch(action: action)
-            }) { [weak self] dispatchFunction, middleware in
-                let getState = { self?.state }
-                return middleware(self?.dispatch, getState)(dispatchFunction)
+            .reduce({ [unowned self] action in return self._defaultDispatch(action: action)
+            }) { [unowned self] dispatchFunction, middleware in
+                let getState: GetState = { self.state }
+                return middleware(self.dispatch, getState)(dispatchFunction)
         }
 
         if let state = state {

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -42,7 +42,7 @@ let dispatchingMiddleware: Middleware = { dispatch, getState in
         return { action in
 
             if var action = action as? SetValueAction {
-                dispatch?(SetValueStringAction("\(action.value)"))
+                dispatch(SetValueStringAction("\(action.value)"))
             }
 
             return next(action)
@@ -60,7 +60,7 @@ let stateAccessingMiddleware: Middleware = { dispatch, getState in
             // avoid endless recursion by checking if we've dispatched exactly this action
             if appState?.testValue == "OK" && stringAction?.value != "Not OK" {
                 // dispatch a new action
-                dispatch?(SetValueStringAction("Not OK"))
+                dispatch(SetValueStringAction("Not OK"))
 
                 // and swallow the current one
                 return next(StandardAction(type: "No-Op-Action"))
@@ -111,7 +111,7 @@ class StoreMiddlewareTests: XCTestCase {
     }
 
     /**
-     it middleware can access the store's state
+     it can access the store's state
      */
     func testMiddlewareCanAccessState() {
         let reducer = TestValueStringReducer()


### PR DESCRIPTION
**Motivation:**
It turns out that there is no need to have an optional dispatch function for the `Middleware`. The only case where it might cause issues (crashes) is when the `Store` gets deallocated and the `Middleware` tries to dispatch a new action. For example this might be a result of the async networking operation or so. However in the idiomatic redux we do not have a temporary store rather a permanent one. Therefore it is very unlikely that store will be deallocated without a middlewares. 

**Impact on the existing code:**
Users will have to replace `dispatch?(action)` by `dispatch(action)` in their middlewares. Xcode detects such things easily. 

**Alternatives considered:**
We can use `weak` instead of `unowned` in the Store during construction of the dispatch function. In addition to this we may also want to print a message during attempt to talk to the deallocated store. 
But going back to the motivation I've decided to go with unowned, because of very low possibility for such case. 