### PR TITLE
Update README example to newer reducer format

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -81,22 +81,18 @@ You can do this implementing a top-level reducer that conforms to the `Reducer` 
 Here's an example in which we construct a new state, by calling sub-reducers with different sub-states:
 
 ```swift
-struct AppReducer: Reducer {
-
-    func handleAction(action: Action, state: State?) -> State {
-        return State(
-            navigationState: NavigationReducer.handleAction(action, state: state?.navigationState),
-            authenticationState: authenticationReducer(state?.authenticationState, action: action),
-            repositories: repositoriesReducer(state?.repositories, action: action),
-            bookmarks: bookmarksReducer(state?.bookmarks, action: action)
-        )
-    }
-
+func appReducer(action: Action, state: State?) -> State {
+    return State(
+      navigationState: navigationReducer(action, state: state?.navigationState),
+      authenticationState: authenticationReducer(state?.authenticationState, action: action),
+      repositories: repositoriesReducer(state?.repositories, action: action),
+      bookmarks: bookmarksReducer(state?.bookmarks, action: action)
+   )
 }
 ```
-The `Reducer` protocol has a single method that takes an `Action` and an `State?` and returns a `State`. Typically reducers will be responsible for initializing the application state. When they receive `nil` as the current state, they should return the initial default value for their portion of the state. In the example above the `AppReducer` delegates all calls to other reducer functions. E.g. the `authenticationReducer` is responsible for providing the `authenticationState`.
+The `Reducer` typealias is a method that takes an `Action` and an `State?` and returns a `State`. Typically reducers will be responsible for initializing the application state. When they receive `nil` as the current state, they should return the initial default value for their portion of the state. In the example above the `appReducer` delegates all calls to other reducer functions. E.g. the `authenticationReducer` is responsible for providing the `authenticationState`.
 
-Here's what the `authenticationReducer` function that is called from the `AppReducer` looks like:
+Here's what the `authenticationReducer` function that is called from the `appReducer` looks like:
 
 ```swift
 func authenticationReducer(state: AuthenticationState?, action: Action) -> AuthenticationState {
@@ -116,13 +112,13 @@ func authenticationReducer(state: AuthenticationState?, action: Action) -> Authe
     return state
 }
 ```
-You can see that the `authenticationReducer` function is a free function. You can define it with any arbitrary method signature, but we recommend that it matches the method in the `Reducer` protocol (current state and action in, new state out).
+You can see that the `authenticationReducer` function is a free function. You can define it with any arbitrary method signature, but we recommend that it matches the `Reducer` typealias (current state and action in, new state out).
 
 This sub-reducer first checks if the state provided is `nil`. If that's the case, it sets the state to the initial default state. Next, the reducer switches over the provided `action` and checks its type. Depending on the type of action, this reducer will updated the state differently. This specific reducer is very simple, each action only triggers a single property of the state to update.
 
 Once the state update is complete, the reducer function returns the new state.
 
-After the `AppReducer` has called all of the sub-reducer functions, we have a new application state. `ReSwift` will take care of publishing this new state to all subscribers.
+After the `appReducer` has called all of the sub-reducer functions, we have a new application state. `ReSwift` will take care of publishing this new state to all subscribers.
 
 # Store Subscribers
 

--- a/README.md
+++ b/README.md
@@ -63,23 +63,19 @@ struct CounterActionDecrease: Action {}
 Your reducer needs to respond to these different action types, that can be done by switching over the type of action:
 
 ```swift
-struct CounterReducer: Reducer {
+func counterReducer(action: Action, state: AppState?) -> AppState {
+    var state = state ?? AppState()
 
-    func handleAction(action: Action, state: AppState?) -> AppState {
-        var state = state ?? AppState()
-
-        switch action {
-        case _ as CounterActionIncrease:
-            state.counter += 1
-        case _ as CounterActionDecrease:
-            state.counter -= 1
-        default:
-            break
-        }
-
-        return state
+    switch action {
+    case _ as CounterActionIncrease:
+        state.counter += 1
+    case _ as CounterActionDecrease:
+        state.counter -= 1
+    default:
+        break
     }
 
+    return state
 }
 ```
 In order to have a predictable app state, it is important that the reducer is always free of side effects, it receives the current app state and an action and returns the new app state.
@@ -88,7 +84,7 @@ To maintain our state and delegate the actions to the reducers, we need a store.
 
 ```swift
 let mainStore = Store<AppState>(
-	reducer: CounterReducer(),
+	reducer: counterReducer,
 	state: nil
 )
 


### PR DESCRIPTION
In #177, `Reducer` was changed from a protocol, requiring the user to create a struct to implement it, to a typealias, allowing one to simply write a function conforming to it. This updates the Readme example to use the new typealias based reducer instead of a struct conforming to the `Reducer` protocol.