### PR TITLE
Update sub-state selection subscription example

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -146,8 +146,8 @@ override func viewWillAppear(animated: Bool) {
 
 	// subscribe when VC appears
    	// we are only interested in repository substate, filter it out of the overall state
-    store.subscribe(self) { state in
-        state.repositories
+    store.subscribe(self) { subcription in
+        subcription.select { state in state.repositories }
     }
 }
 


### PR DESCRIPTION
Updates the sub-state selection example to match the new syntax from https://github.com/ReSwift/ReSwift/pull/203