### PR TITLE
Make Middleware's `getState` generic

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -247,7 +247,7 @@ Let's take a look at a quick example that shows how ReSwift supports Redux style
 The simplest example of a middleware, is one that prints all actions to the console. Here's how you can implement it:
 
 ```swift
-let loggingMiddleware: Middleware = { dispatch, getState in
+let loggingMiddleware: Middleware<Any> = { dispatch, getState in
     return { next in
         return { action in
             // perform middleware logic
@@ -259,6 +259,8 @@ let loggingMiddleware: Middleware = { dispatch, getState in
     }
 }
 ```
+The generic in middleware refers to the return type in `getState`, and needs to be compatible with the `State` associated type in your `Store`.
+
 You can define which middleware you would like to use when creating your store:
 
 ```swift

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public typealias DispatchFunction = (Action) -> Void
-public typealias GetState = () -> StateType?
-public typealias Middleware =
-    (DispatchFunction?, @escaping GetState) -> (@escaping DispatchFunction) -> DispatchFunction
+public typealias GetState<State> = () -> State?
+public typealias Middleware<State> = (DispatchFunction?, @escaping GetState<State>)
+    -> (@escaping DispatchFunction) -> DispatchFunction

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -9,6 +9,5 @@
 import Foundation
 
 public typealias DispatchFunction = (Action) -> Void
-public typealias GetState<State> = () -> State?
-public typealias Middleware<State> = (DispatchFunction?, @escaping GetState<State>)
+public typealias Middleware<State> = (DispatchFunction?, @escaping () -> State?)
     -> (@escaping DispatchFunction) -> DispatchFunction

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -43,7 +43,7 @@ open class Store<State: StateType>: StoreType {
     public required init(
         reducer: @escaping Reducer<State>,
         state: State?,
-        middleware: [Middleware] = []
+        middleware: [Middleware<State>] = []
     ) {
         self.reducer = reducer
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -20,7 +20,7 @@ public protocol StoreType: DispatchingStoreType {
 
     /// Initializes the store with a reducer, an initial state and a list of middleware.
     /// Middleware is applied in the order in which it is passed into this constructor.
-    init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware])
+    init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware<State>])
 
     /// The current state stored in the store.
     var state: State! { get }

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import ReSwift
 
-let firstMiddleware: Middleware = { dispatch, getState in
+let firstMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -23,7 +23,7 @@ let firstMiddleware: Middleware = { dispatch, getState in
     }
 }
 
-let secondMiddleware: Middleware = { dispatch, getState in
+let secondMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -37,7 +37,7 @@ let secondMiddleware: Middleware = { dispatch, getState in
     }
 }
 
-let dispatchingMiddleware: Middleware = { dispatch, getState in
+let dispatchingMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -50,11 +50,11 @@ let dispatchingMiddleware: Middleware = { dispatch, getState in
     }
 }
 
-let stateAccessingMiddleware: Middleware = { dispatch, getState in
+let stateAccessingMiddleware: Middleware<TestStringAppState> = { dispatch, getState in
     return { next in
         return { action in
 
-            let appState = getState() as? TestStringAppState,
+            let appState = getState(),
                 stringAction = action as? SetValueStringAction
 
             // avoid endless recursion by checking if we've dispatched exactly this action

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -56,8 +56,11 @@ class DeInitStore<State: StateType>: Store<State> {
             self.deInitAction = deInitAction
     }
 
-    required init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware<State>]) {
-        super.init(reducer: reducer, state: state, middleware: middleware)
+    required init(
+        reducer: @escaping Reducer<State>,
+        state: State?,
+        middleware: [Middleware<State>]) {
+            super.init(reducer: reducer, state: state, middleware: middleware)
     }
 }
 

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -56,7 +56,7 @@ class DeInitStore<State: StateType>: Store<State> {
             self.deInitAction = deInitAction
     }
 
-    required init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware]) {
+    required init(reducer: @escaping Reducer<State>, state: State?, middleware: [Middleware<State>]) {
         super.init(reducer: reducer, state: state, middleware: middleware)
     }
 }


### PR DESCRIPTION
This allows for us to specify the state type that middleware uses, providing compile-time assurance of state contents, instead of requiring the user to deal with conditional type-casting during runtime.

This seems to have an issue compiling with Xcode 8.2, but works fine in 8.3.

- [x] Update documentation
- [x] Figure out why the build times out in xcode 8.2