### PR TITLE
[Cleanup] Remove Superfluous DiscardableResult

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -80,7 +80,6 @@ open class Store<State: StateType>: StoreType {
             _ = subscribe(subscriber, transform: nil)
     }
 
-    @discardableResult
     open func subscribe<SelectedState, S: StoreSubscriber>(
         _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?
     ) where S.StoreSubscriberStateType == SelectedState


### PR DESCRIPTION
This generates a warning in Xcode 8.3.