### PR TITLE
Fix improperly formatted Markdown headings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing to ReSwift
+# Contributing to ReSwift
 
 Some design decisions for the core of ReSwift are still up in the air (see [issues](https://github.com/ReSwift/ReSwift/issues)), there's lots of useful documentation that can be written and a ton of extensions and tools are waiting to be built on top of ReSwift.
 

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -167,9 +167,9 @@ When selecting a substate as part of calling the `subscribe` method, you need to
 
 When subscribing within a ViewController you will typically update the view from within the `newState` method.
 
-#Beyond the Basics
+# Beyond the Basics
 
-##Asynchronous Operations
+## Asynchronous Operations
 
 Conceptually asynchronous operations can simply be treated as state updates that occur at a later point in time. Here's a simple example of how to tie an asynchronous network request to `ReSwift` state update:
 
@@ -214,7 +214,7 @@ func fetchGitHubRepositories(state: State, store: Store<State>) -> Action? {
 
 In the example above, we're using an `enum` to represent the different states of a single state slice that depends on a network request (e.g. loading, result available, network request failed). There are many different ways to model states of a network request but it will mostly involve using multiple dispatched actions at different stages of your network requests.
 
-##Action Creators
+## Action Creators
 
 An important aspect of adopting `ReSwift` is an improved separation of concerns. Specifically, your view layer should mostly be concerned with adopting its representation to match a new app state and for triggering `Action`s upon user interactions.
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This repository contains the core component for ReSwift, the following extension
 - [GitHubBrowserExample](https://github.com/ReSwift/GitHubBrowserExample): A real world example, involving authentication, network requests and navigation. Still WIP but should be the best resource for starting to adapt `ReSwift` in your own app.
 - [Meet](https://github.com/Ben-G/Meet): A real world application being built with ReSwift - currently still very early on. It is not up to date with the latest version of ReSwift, but is the best project for demonstrating time travel.
 
-##Production Apps with Open Source Code
+## Production Apps with Open Source Code
 
 - [Product Hunt for OS X](https://github.com/producthunt/producthunt-osx) Official Product Hunt client for OS X.
 


### PR DESCRIPTION
Was browsing the repository when I noticed that some of your documentation's headers aren't displaying properly on GitHub. I think [there was a recent change to the site's markdown parsing](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown) whereby [headers now require a space between the hash marks and the actual words in the header](https://github.github.com/gfm/#atx-headings).

As far as I can tell this doesn't affect any of the auto-generated docs on http://reswift.github.io, so I didn't regenerate those.