### PR TITLE
Fix SwiftLint errors and warnings

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -119,6 +119,7 @@ open class Store<State: StateType>: StoreType {
         }
     }
 
+    // swiftlint:disable:next identifier_name
     open func _defaultDispatch(action: Action) {
         guard !isDispatching else {
             raiseFatalError(

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public protocol AnyStoreSubscriber: class {
+    // swiftlint:disable:next identifier_name
     func _newState(state: Any)
 }
 
@@ -19,6 +20,7 @@ public protocol StoreSubscriber: AnyStoreSubscriber {
 }
 
 extension StoreSubscriber {
+    // swiftlint:disable:next identifier_name
     public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
             newState(state: typedState)

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -32,13 +32,13 @@ class SubscriptionBox<State> {
         // If we received a transformed subscription, we subscribe to that subscription
         // and forward all new values to the subscriber.
         if let transformedSubscription = transformedSubscription {
-            transformedSubscription.observe { oldState, newState in
+            transformedSubscription.observe { _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         // If we haven't received a transformed subscription, we forward all values
         // from the original subscription.
         } else {
-            originalSubscription.observe { oldState, newState in
+            originalSubscription.observe { _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         }

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -112,7 +112,7 @@ public class Subscription<State> {
 
     // MARK: Internals
 
-    var observer: ((State?, State?) -> Void)? = nil
+    var observer: ((State?, State?) -> Void)?
 
     init() {}
 

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -16,7 +16,7 @@ class StoreTests: XCTestCase {
      */
     func testInit() {
         let reducer = MockReducer()
-        let _ = Store<CounterState>(reducer: reducer.handleAction, state: nil)
+        _ = Store<CounterState>(reducer: reducer.handleAction, state: nil)
 
         XCTAssert(reducer.calledWithAction[0] is ReSwiftInit)
     }
@@ -29,7 +29,7 @@ class StoreTests: XCTestCase {
 
         autoreleasepool {
             let reducer = TestReducer()
-            let _ = DeInitStore(
+            _ = DeInitStore(
                 reducer: reducer.handleAction,
                 state: TestAppState(),
                 deInitAction: { deInitCount += 1 })


### PR DESCRIPTION
### :pushpin: References
* **Issue:** None
* **Related pull-requests:** None

### :tophat: What is the goal?

Fixing the errors and warnings reported by latest (0.17.0) version of SwiftLint. The project does not compile with the latest version of SwitLint :

```bash
~/Desktop
git clone git@github.com:ReSwift/ReSwift.git
Cloning into 'ReSwift'...
remote: Counting objects: 2309, done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 2309 (delta 0), reused 0 (delta 0), pack-reused 2301
Receiving objects: 100% (2309/2309), 4.18 MiB | 825.00 KiB/s, done.
Resolving deltas: 100% (1204/1204), done.

~/Desktop 7s
cd ReSwift

~/Desktop/ReSwift master
xcodebuild -project ReSwift.xcodeproj | xcpretty
▸ Building ReSwift/ReSwift-iOS [(Release)]
▸ Check Dependencies
▸ Processing Info.plist
▸ Compiling ReSwift_vers.c
▸ Compiling ReSwift_vers.c
▸ Linking ReSwift
▸ Linking ReSwift
▸ Copying ReSwift.h
▸ Running script 'SwiftLint'
** BUILD FAILED **


The following build commands failed:
	PhaseScriptExecution SwiftLint build/ReSwift.build/Release-iphoneos/ReSwift-iOS.build/Script-621C06541C277459008029AE.sh
(1 failure)
```

### How is it being implemented?

- Ignore `identifier_name` rule for methods beginning with underscore
- Fix warnings and errors for all the other rules