### PR TITLE
Generic ActionCreator

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -224,7 +224,7 @@ Just like an `Action` a `ActionCreator` function can be dispatched to the store.
 
 An `ActionCreator` has the following type signature:
 ```swift
-typealias ActionCreator = (state: State) -> Action?
+typealias ActionCreator<S: StateType> = (state: S) -> Action?
 ```
 
 A very simple example of an `ActionCreator` might be:

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -220,16 +220,16 @@ An important aspect of adopting `ReSwift` is an improved separation of concerns.
 
 The triggering of actions should always be as simple as possible, we want to avoid any sort of complicated business logic in the view. However, in some cases it can be complicated to decide whether an action should be dispatched or not. Instead of checking the necessary state directly in the view or view controller, you can use `ActionCreator`s to perform a conditional dispatch.
 
-Just like an `Action` a `ActionCreator` function can be dispatched to the store. An `ActionCreator` takes the current application state, and a reference to a store and might or might not return an `Action`.
+Just like an `Action` a `ActionCreator` function can be dispatched to the store. An `ActionCreator` takes the current application state and might or might not return an `Action`.
 
 An `ActionCreator` has the following type signature:
 ```swift
-typealias ActionCreator = (state: State, store: StoreType) -> Action?
+typealias ActionCreator = (state: State) -> Action?
 ```
 
 A very simple example of an `ActionCreator` might be:
 ```swift
-func doubleValueIfSmall(state: TestAppState, store: Store<TestAppState>) -> Action? {
+func doubleValueIfSmall(state: TestAppState) -> Action? {
 	if state.testValue < 5 {
 		return SetValueAction(state.testValue! * 2)
 	} else {

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -85,6 +85,10 @@
 		81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
 		81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
 		81BCBED11C63167A00AA4F03 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BCBECD1C63167A00AA4F03 /* Subscription.swift */; };
+		D419C63D1E8AF29100D918C2 /* ActionCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419C63C1E8AF29100D918C2 /* ActionCreator.swift */; };
+		D419C63E1E8AF30C00D918C2 /* ActionCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419C63C1E8AF29100D918C2 /* ActionCreator.swift */; };
+		D419C63F1E8AF30D00D918C2 /* ActionCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419C63C1E8AF29100D918C2 /* ActionCreator.swift */; };
+		D419C6401E8AF30E00D918C2 /* ActionCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419C63C1E8AF29100D918C2 /* ActionCreator.swift */; };
 		D47D2D561E32C3F50064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
 		D47D2D571E32C4170064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
 		D47D2D581E32C4180064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
@@ -147,6 +151,7 @@
 		73F39F331D3EE3C300DFFE62 /* StoreDispatchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreDispatchTests.swift; sourceTree = "<group>"; };
 		73F39F371D3EE46A00DFFE62 /* StoreSubscriptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSubscriptionTests.swift; sourceTree = "<group>"; };
 		81BCBECD1C63167A00AA4F03 /* Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
+		D419C63C1E8AF29100D918C2 /* ActionCreator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionCreator.swift; sourceTree = "<group>"; };
 		D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchingStoreType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -272,6 +277,7 @@
 			isa = PBXGroup;
 			children = (
 				625E66B61C1FFC880027C288 /* Action.swift */,
+				D419C63C1E8AF29100D918C2 /* ActionCreator.swift */,
 				D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */,
 				259737FC1C2C661100869B8F /* Middleware.swift */,
 				625E66B81C1FFC880027C288 /* Reducer.swift */,
@@ -603,6 +609,7 @@
 				25DBCF451C30C16000D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF461C30C16000D63A58 /* Middleware.swift in Sources */,
 				25DBCF471C30C16000D63A58 /* Coding.swift in Sources */,
+				D419C6401E8AF30E00D918C2 /* ActionCreator.swift in Sources */,
 				D47D2D591E32C4190064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF481C30C16000D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -622,6 +629,7 @@
 				25DBCF5C1C30C19500D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF5D1C30C19500D63A58 /* Middleware.swift in Sources */,
 				25DBCF5E1C30C19500D63A58 /* Coding.swift in Sources */,
+				D419C63F1E8AF30D00D918C2 /* ActionCreator.swift in Sources */,
 				D47D2D581E32C4180064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF5F1C30C19500D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -658,6 +666,7 @@
 				25DBCF981C30C4F000D63A58 /* StoreSubscriber.swift in Sources */,
 				25DBCF991C30C4F000D63A58 /* Middleware.swift in Sources */,
 				25DBCF9A1C30C4F000D63A58 /* Coding.swift in Sources */,
+				D419C63E1E8AF30C00D918C2 /* ActionCreator.swift in Sources */,
 				D47D2D571E32C4170064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF9B1C30C4F000D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -694,6 +703,7 @@
 				81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				625E66BE1C1FFC880027C288 /* Reducer.swift in Sources */,
 				625E66B41C1FFC830027C288 /* TypeHelper.swift in Sources */,
+				D419C63D1E8AF29100D918C2 /* ActionCreator.swift in Sources */,
 				D47D2D561E32C3F50064769E /* DispatchingStoreType.swift in Sources */,
 				625E66BF1C1FFC880027C288 /* State.swift in Sources */,
 			);

--- a/ReSwift/CoreTypes/ActionCreator.swift
+++ b/ReSwift/CoreTypes/ActionCreator.swift
@@ -1,0 +1,31 @@
+//
+//  ActionCreator.swift
+//  ReSwift
+//
+//  Created by Malcolm Jarvis on 2017-03-28.
+//  Copyright © 2017 Benjamin Encz. All rights reserved.
+//
+
+import Foundation
+
+/**
+ An ActionCreator is a function that, based on the received state argument, might or might not
+ create an action.
+
+ Example:
+
+ ```
+ func deleteNote(noteID: Int) -> ActionCreator<AppState> {
+    return { state in
+        // only delete note if editing is enabled
+        if (state.editingEnabled == true) {
+            return NoteDataAction.DeleteNote(noteID)
+        } else {
+            return nil
+        }
+    }
+ }
+ ```
+
+ */
+public typealias ActionCreator<S: StateType> = (_ state: S) -> Action?

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -142,7 +142,7 @@ open class Store<State: StateType>: StoreType {
     }
 
     open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) {
-        if let action = actionCreatorProvider(state, self) {
+        if let action = actionCreatorProvider(state) {
             dispatch(action)
         }
     }
@@ -154,7 +154,7 @@ open class Store<State: StateType>: StoreType {
     open func dispatch(_ actionCreatorProvider: @escaping AsyncActionCreator,
                        callback: DispatchCallback?) {
         actionCreatorProvider(state, self) { actionProvider in
-            let action = actionProvider(self.state, self)
+            let action = actionProvider(self.state)
 
             if let action = action {
                 self.dispatch(action)
@@ -165,7 +165,7 @@ open class Store<State: StateType>: StoreType {
 
     public typealias DispatchCallback = (State) -> Void
 
-    public typealias ActionCreator = (_ state: State, _ store: Store) -> Action?
+    public typealias ActionCreator = (_ state: State) -> Action?
 
     public typealias AsyncActionCreator = (
         _ state: State,

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -141,7 +141,7 @@ open class Store<State: StateType>: StoreType {
         dispatchFunction(action)
     }
 
-    open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) {
+    open func dispatch(_ actionCreatorProvider: ActionCreator<State>) {
         if let action = actionCreatorProvider(state) {
             dispatch(action)
         }
@@ -165,12 +165,10 @@ open class Store<State: StateType>: StoreType {
 
     public typealias DispatchCallback = (State) -> Void
 
-    public typealias ActionCreator = (_ state: State) -> Action?
-
     public typealias AsyncActionCreator = (
         _ state: State,
         _ store: Store,
-        _ actionCreatorCallback: @escaping ((ActionCreator) -> Void)
+        _ actionCreatorCallback: @escaping ((ActionCreator<State>) -> Void)
     ) -> Void
 }
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -75,8 +75,8 @@ public protocol StoreType: DispatchingStoreType {
      Example of an action creator:
 
      ```
-     func deleteNote(noteID: Int) -> ActionCreator {
-        return { state, store in
+     func deleteNote(noteID: Int) -> Store<AppState>.ActionCreator {
+        return { state in
             // only delete note if editing is enabled
             if (state.editingEnabled == true) {
                 return NoteDataAction.DeleteNote(noteID)
@@ -90,7 +90,7 @@ public protocol StoreType: DispatchingStoreType {
      This action creator can then be dispatched as following:
 
      ```
-     store.dispatch( noteActionCreatore.deleteNote(3) )
+     store.dispatch( deleteNote(3) )
      ```
 
      - returns: By default returns the dispatched action, but middlewares can change the
@@ -133,8 +133,8 @@ public protocol StoreType: DispatchingStoreType {
      Example:
 
      ```
-     func deleteNote(noteID: Int) -> ActionCreator {
-        return { state, store in
+     func deleteNote(noteID: Int) -> Store<AppState>.ActionCreator {
+        return { state in
             // only delete note if editing is enabled
             if (state.editingEnabled == true) {
                 return NoteDataAction.DeleteNote(noteID)
@@ -146,7 +146,7 @@ public protocol StoreType: DispatchingStoreType {
      ```
 
      */
-    associatedtype ActionCreator = (_ state: State, _ store: StoreType) -> Action?
+    associatedtype ActionCreator = (_ state: State) -> Action?
 
     /// AsyncActionCreators allow the developer to wait for the completion of an async action.
     associatedtype AsyncActionCreator =

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -96,7 +96,7 @@ public protocol StoreType: DispatchingStoreType {
      - returns: By default returns the dispatched action, but middlewares can change the
      return type, e.g. to return promises
      */
-    func dispatch(_ actionCreator: ActionCreator)
+    func dispatch(_ actionCreator: ActionCreator<State>)
 
     /**
      Dispatches an async action creator to the store. An async action creator generates an
@@ -126,30 +126,8 @@ public protocol StoreType: DispatchingStoreType {
      */
     associatedtype DispatchCallback = (State) -> Void
 
-    /**
-     An ActionCreator is a function that, based on the received state argument, might or might not
-     create an action.
-
-     Example:
-
-     ```
-     func deleteNote(noteID: Int) -> Store<AppState>.ActionCreator {
-        return { state in
-            // only delete note if editing is enabled
-            if (state.editingEnabled == true) {
-                return NoteDataAction.DeleteNote(noteID)
-            } else {
-                return nil
-            }
-        }
-     }
-     ```
-
-     */
-    associatedtype ActionCreator = (_ state: State) -> Action?
-
     /// AsyncActionCreators allow the developer to wait for the completion of an async action.
     associatedtype AsyncActionCreator =
         (_ state: State, _ store: StoreType,
-         _ actionCreatorCallback: (ActionCreator) -> Void) -> Void
+         _ actionCreatorCallback: (ActionCreator<State>) -> Void) -> Void
 }

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -40,7 +40,22 @@ class StoreDispatchTests: XCTestCase {
     func testAcceptsActionCreators() {
         store.dispatch(SetValueAction(5))
 
-        let doubleValueActionCreator: Store<TestAppState>.ActionCreator = { state in
+        let doubleValueActionCreator: ActionCreator<TestAppState> = { state in
+            return SetValueAction(state.testValue! * 2)
+        }
+
+        store.dispatch(doubleValueActionCreator)
+
+        XCTAssertEqual(store.state.testValue, 10)
+    }
+
+    /**
+     it accepts action creators specifying a protocol to which Store.State conforms
+     */
+    func testAcceptsConformingActionCreators() {
+        store.dispatch(SetValueAction(5))
+
+        let doubleValueActionCreator: ActionCreator<HasTestValue> = { state in
             return SetValueAction(state.testValue! * 2)
         }
 

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -40,7 +40,7 @@ class StoreDispatchTests: XCTestCase {
     func testAcceptsActionCreators() {
         store.dispatch(SetValueAction(5))
 
-        let doubleValueActionCreator: Store<TestAppState>.ActionCreator = { state, store in
+        let doubleValueActionCreator: Store<TestAppState>.ActionCreator = { state in
             return SetValueAction(state.testValue! * 2)
         }
 
@@ -60,7 +60,7 @@ class StoreDispatchTests: XCTestCase {
         let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
             dispatchAsync {
                 // Provide the callback with an action creator
-                callback { _, _ in
+                callback { _ in
                     return SetValueAction(5)
                 }
             }
@@ -92,7 +92,7 @@ class StoreDispatchTests: XCTestCase {
         let asyncActionCreator: Store<TestAppState>.AsyncActionCreator = { _, _, callback in
             dispatchAsync {
                 // Provide the callback with an action creator
-                callback { _, _ in
+                callback { _ in
                     return SetValueAction(5)
                 }
             }

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -9,7 +9,11 @@
 import Foundation
 import ReSwift
 
-struct TestAppState: StateType {
+protocol HasTestValue {
+    var testValue: Int? { get }
+}
+
+struct TestAppState: StateType, HasTestValue {
     var testValue: Int?
 
     init() {


### PR DESCRIPTION
This splits ActionCreator out of `StoreType` and makes it a stand-alone
generic typealias. This allows one to define an action creator without the
context of the store its being called on, and lets you use that action
creator on any conforming store. This allows more isolated action creators
that need only know about some sub-state.

See `testAcceptsConformingActionCreators` for an example.

A requirement for this is also removing the `Store` argument from `ActionCreator`.

I can't see a valid use case for providing the store to an action creator, anyways.
Including it seems to encourage bad practices such as accessing the state
via the store, or dispatching additional actions from an action creator,
which I feel should be discouraged.