### PR TITLE
[Store] Test Duplicate Subscriptions

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -67,17 +67,6 @@ open class Store<State: StateType>: StoreType {
         }
     }
 
-    private func _isNewSubscriber(subscriber: AnyStoreSubscriber) -> Bool {
-        let contains = subscriptions.contains(where: { $0.subscriber === subscriber })
-
-        if contains {
-            print("Store subscriber is already added, ignoring.")
-            return false
-        }
-
-        return true
-    }
-
     open func subscribe<S: StoreSubscriber>(_ subscriber: S)
         where S.StoreSubscriberStateType == State {
             _ = subscribe(subscriber, transform: nil)

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -65,6 +65,29 @@ class StoreSubscriptionTests: XCTestCase {
     }
 
     /**
+     it replaces the subscription of an existing subscriber with the new one.
+     */
+    func testDuplicateSubscription() {
+        store = Store(reducer: reducer.handleAction, state: TestAppState())
+        let subscriber = TestSubscriber()
+
+        // Initial subscription.
+        store.subscribe(subscriber)
+        // Subsequent subscription that skips repeated updates.
+        store.subscribe(subscriber) { $0.skipRepeats { $0.testValue == $1.testValue } }
+
+        // One initial state update for every subscription.
+        XCTAssertEqual(subscriber.receivedStates.count, 2)
+
+        store.dispatch(SetValueAction(3))
+        store.dispatch(SetValueAction(3))
+        store.dispatch(SetValueAction(3))
+        store.dispatch(SetValueAction(3))
+
+        // Only a single further state update, since latest subscription skips repeated values.
+        XCTAssertEqual(subscriber.receivedStates.count, 3)
+    }
+    /**
      it dispatches initial value upon subscription
      */
     func testDispatchInitialValue() {


### PR DESCRIPTION
In case of subscribing with an already existing subscriber, the latest subscription should replace the previous one. This commit adds a test for this.

It also removes dead code: the old an unused version of checking for an existing subscriber.