### PR TITLE
[Release] Stop Producing Binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,17 +44,3 @@ after_success:
     test $TRAVIS_BRANCH == "master" &&
     test $UPDATE_DOCS == "true" &&
     .scripts/update-gh-pages
-
-before_deploy:
-  - carthage build --no-skip-current
-  - carthage archive $FRAMEWORK_NAME
-
-deploy:
-  provider: releases
-  api_key:
-    secure: S5BWCiwX80EWjF5043d1EVPw59qpuVTI1ytPejEE9bFomVDj0kCYIqodlUmKRorutNr+t2UD5CwTyqs5qHaAuseAm0P6SrOp1GaP9m6Jb/surII4nMICx+TzFP8xdCwC+C74CUDuCLeyM++kxIZEwJOp/QF9iP3iaF54ed+4IlycVEGxJ4LQQRBaQ3X+u6L/bSCgL/HuRzs0W1QXYovbFzCvEQmYlSQi00x5BGHtk3Rj4zU320pmcE1Ne0dGsmITN0oA2qSborVFPo1CnjRGKAJD8TJZRmxmKygFOQpsD4px/IRswDJRle5cGjvZ+MLnvDBis5siTGOf3W1z/HxTomqCIeAGt4O5CfJP9NP9HjaV9ATFb2NSpZPNaVle4IhfSl2O7NuQyhh19UKz9xgZ9QknkddZBPQ4yEINHAEzqVDKHjCvZZH4pxjN6AcbaKPYBoL042FmS87HAmq32AcOVBM0eXhMUzucahYTw1+XS77ZkOrXdx2jXX1hyjZ7tooYYm3SHJxHJKufnv5/rfShTM70+4vVhLePYGt/FnduacPdNtIehit7v6Dj+xsTs5igWMx/0Bb6ccaRr2ZQGs0dq536x0zrQVrvkrW9HcOY1uohFqujLGjJ/i6U1aMBf+iPRDTHlVmqiYjVSRC1mhatGOVHv+UuA1dSPkK9F91Lxbs=
-  file: "$FRAMEWORK_NAME.framework.zip"
-  skip_cleanup: true
-  on:
-    repo: ReSwift/ReSwift
-    tags: true


### PR DESCRIPTION
Using precompiled binary frameworks is not supported by Apple. Further,
the pre-built binaries are being built with the version of Swift that is
current at the time of the release. This leads to problems of Swift version
mismatches when trying to install ReSwift via Carthage.
I suggest we stop producing and publishing binaries.