### PR TITLE
Add Subscription `skip(when:)` and `only(when:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming
+
+**Other**:
+- Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
+
 # 4.0.0
 
 *Work in Progress*

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -95,7 +95,8 @@ public class Subscription<State> {
     /// thus should be skipped and not forwarded to subscribers.
     /// - parameter oldState: The store's old state, before the action is reduced.
     /// - parameter newState: The store's new state, after the action has been reduced.
-    public func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Bool) -> Subscription<State> {
+    public func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Bool)
+        -> Subscription<State> {
         return Subscription<State> { sink in
             self.observe { oldState, newState in
                 switch (oldState, newState) {

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -93,7 +93,9 @@ public class Subscription<State> {
     /// Provides a subscription that skips certain state updates of the original subscription.
     /// - parameter isRepeat: A closure that determines whether a given state update is a repeat and
     /// thus should be skipped and not forwarded to subscribers.
-    public func skipRepeats(_ isRepeat: @escaping (State, State) -> Bool) -> Subscription<State> {
+    /// - parameter oldState: The store's old state, before the action is reduced.
+    /// - parameter newState: The store's new state, after the action has been reduced.
+    public func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Bool) -> Subscription<State> {
         return Subscription<State> { sink in
             self.observe { oldState, newState in
                 switch (oldState, newState) {

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -143,3 +143,31 @@ extension Subscription where State: Equatable {
         return self.skipRepeats(==)
     }
 }
+
+/// Subscription skipping convenience methods
+extension Subscription {
+
+    /// Provides a subscription that skips certain state updates of the original subscription.
+    ///
+    /// This is identical to `skipRepeats` and is provided simply for convenience.
+    /// - parameter when: A closure that determines whether a given state update is a repeat and
+    /// thus should be skipped and not forwarded to subscribers.
+    /// - parameter oldState: The store's old state, before the action is reduced.
+    /// - parameter newState: The store's new state, after the action has been reduced.
+    public func skip(when: @escaping (_ oldState: State, _ newState: State) -> Bool) -> Subscription<State> {
+        return self.skipRepeats(when)
+    }
+
+    /// Provides a subscription that only updates for certain state changes.
+    ///
+    /// This is effectively the inverse of `skip(when:)` / `skipRepeats(:)`
+    /// - parameter when: A closure that determines whether a given state update should notify
+    /// - parameter oldState: The store's old state, before the action is reduced.
+    /// - parameter newState: The store's new state, after the action has been reduced.
+    /// the subscriber.
+    public func only(when: @escaping (_ oldState: State, _ newState: State) -> Bool) -> Subscription<State> {
+        return self.skipRepeats { oldState, newState in
+            return !when(oldState, newState)
+        }
+    }
+}

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -157,6 +157,43 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
+    func testSkipWhen() {
+        let reducer = TestCustomAppStateReducer()
+        let state = TestCustomAppState(substateValue: 5)
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
+
+        store.subscribe(subscriber) {
+            $0.select { $0.substate }
+                .skip { $0.value == $1.value }
+        }
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+
+        store.dispatch(SetCustomSubstateAction(5))
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
+
+    func testOnlyWhen() {
+        let reducer = TestCustomAppStateReducer()
+        let state = TestCustomAppState(substateValue: 5)
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
+
+        store.subscribe(subscriber) {
+            $0.select { $0.substate }
+                .only { $0.value != $1.value }
+        }
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+
+        store.dispatch(SetCustomSubstateAction(5))
+
+        XCTAssertEqual(subscriber.receivedValue.value, 5)
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
 }
 
 class TestFilteredSubscriber<T>: StoreSubscriber {


### PR DESCRIPTION
These subscription filtering methods are provided as convenience methods for `skipRepeats`.

1. `skip(when:)` is a direct forward to `skipRepeats` and is simply provided as a more swift-like naming option.
2. `only(when:)` is the inverse to `skipRepeats`, and is provided for specifying when the user wants the subscription to notify, as opposed to when to skip notifying.

Both of these functions are technically "sugar", however I feel like they add value to the library by making the available use cases of `skipRepeats` more obvious to users.

For example, a user could chain calls to these, such as `$0.select({ $0.child }).skip(when: { $0.identifier == $1.identifier }).only(when: { $1.name.lowercased.hasPrefix("a") })` which would notify the subscriber when the child changes, and the new child's `name` starts with "a"

Also adds a bit more documentation to `skipRepeats`.