### PR TITLE
Update release date for 4.0.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.0.0
 
-*Work in Progress*
+*Released: 4/19/2017*
 
 **Breaking API Changes:**
 


### PR DESCRIPTION
I based this change on the date listed in [Github releases](https://github.com/ReSwift/ReSwift/releases/tag/4.0.0). Feel free to edit my commit if this assumption was incorrect 😸 