### PR TITLE
Add test example for double equatable check

### DIFF
--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -157,6 +157,35 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
+    /**
+     It avoids default skipRepeats when custom skipRepeats is implemented.
+     */
+    func testCallsEquatableOnceForStateChange() {
+        let reducer = testCustomEquatableReducer
+        let state = TestCustomEquatableAppState()
+        let store = Store(reducer: reducer, state: state)
+        let subscriber = TestFilteredSubscriber<CustomEquatable>()
+        customEquatableCount = 0
+        var customSkipCount = 0
+
+        store.subscribe(subscriber) {
+            $0.select { $0.testValue }.skipRepeats {
+                customSkipCount += 1
+                return $0.value == $1.value
+            }
+        }
+
+        XCTAssertEqual(customEquatableCount, 0)
+        XCTAssertEqual(subscriber.receivedValue.value, 0)
+        XCTAssertEqual(customSkipCount, 0)
+
+        store.dispatch(SetValueAction(1))
+
+        XCTAssertEqual(subscriber.receivedValue.value, 1)
+        XCTAssertEqual(subscriber.newStateCallCount, 2)
+        XCTAssertEqual(customEquatableCount, 0)
+        XCTAssertEqual(customSkipCount, 1)
+    }
 }
 
 class TestFilteredSubscriber<T>: StoreSubscriber {

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -186,3 +186,31 @@ class CallbackStoreSubscriber<T>: StoreSubscriber {
         handler(state)
     }
 }
+
+var customEquatableCount: Int = 0
+
+struct CustomEquatable: Equatable {
+    var value: Int = 0
+    var customEquatCount: Int = 0
+
+    static func ==(left: CustomEquatable, right: CustomEquatable) -> Bool {
+        customEquatableCount += 1
+        return left.value == right.value
+    }
+}
+
+struct TestCustomEquatableAppState: StateType {
+    var testValue: CustomEquatable = CustomEquatable()
+}
+
+func testCustomEquatableReducer(action: Action, state: TestCustomEquatableAppState?) -> TestCustomEquatableAppState {
+    var state = state ?? TestCustomEquatableAppState()
+
+    switch action {
+    case let action as SetValueAction:
+        state.testValue.value = action.value
+        return state
+    default:
+        return state
+    }
+}


### PR DESCRIPTION
Having a default implementation for `skipRepeats` when the selected state is equatable causes what could be a performance issue when the user implements their own `skipRepeats`.
The original default implementation is still called, even though a default exists.
This could also cause unwanted behaviour if the custom skipRepeats wants to compare something not checked in the default equatable.