### PR TITLE
Ignore Tests target in code coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "ReSwiftTests"


### PR DESCRIPTION
There is no need for us to count the tests themselves when calculating code coverage.
The only use for it is to find unused test code for pruning, which we can still do manually in xcode, while providing a more accurate code coverage for users visiting the github page, and for PR reports.