### PR TITLE
[Fix] Make New State Non-Optional

### DIFF
--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -64,7 +64,7 @@ public class Subscription<State> {
     {
         return Subscription<Substate> { sink in
             self.observe { oldState, newState in
-                sink(oldState.map(selector) ?? nil, newState.map(selector) ?? nil)
+                sink(oldState.map(selector) ?? nil, selector(newState))
             }
         }
     }
@@ -100,7 +100,7 @@ public class Subscription<State> {
         return Subscription<State> { sink in
             self.observe { oldState, newState in
                 switch (oldState, newState) {
-                case let (old?, new?):
+                case let (old?, new):
                     if !isRepeat(old, new) {
                         sink(oldState, newState)
                     } else {
@@ -115,13 +115,13 @@ public class Subscription<State> {
 
     // MARK: Internals
 
-    var observer: ((State?, State?) -> Void)?
+    var observer: ((State?, State) -> Void)?
 
     init() {}
 
     /// Initializes a subscription with a sink closure. The closure provides a way to send
     /// new values over this subscription.
-    private init(sink: @escaping (@escaping (State?, State?) -> Void) -> Void) {
+    private init(sink: @escaping (@escaping (State?, State) -> Void) -> Void) {
         // Provide the caller with a closure that will forward all values
         // to observers of this subscription.
         sink { old, new in
@@ -130,13 +130,13 @@ public class Subscription<State> {
     }
 
     /// Sends new values over this subscription. Observers will be notified of these new values.
-    func newValues(oldState: State?, newState: State?) {
+    func newValues(oldState: State?, newState: State) {
         self.observer?(oldState, newState)
     }
 
     /// A caller can observe new values of this subscription through the provided closure.
     /// - Note: subscriptions only support a single observer.
-    fileprivate func observe(observer: @escaping (State?, State?) -> Void) {
+    fileprivate func observe(observer: @escaping (State?, State) -> Void) {
         self.observer = observer
     }
 }

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -42,7 +42,7 @@ let dispatchingMiddleware: Middleware<StateType> = { dispatch, getState in
         return { action in
 
             if var action = action as? SetValueAction {
-                dispatch(SetValueStringAction("\(action.value)"))
+                dispatch(SetValueStringAction("\(action.value ?? 0)"))
             }
 
             return next(action)

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -26,6 +26,10 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueAction(3))
 
         XCTAssertEqual(subscriber.receivedValue, 3)
+
+        store.dispatch(SetValueAction(nil))
+
+        XCTAssertEqual(subscriber.receivedValue, nil)
     }
 
     /**

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -49,15 +49,15 @@ struct TestCustomAppState: StateType {
 
 struct SetValueAction: StandardActionConvertible {
 
-    let value: Int
+    let value: Int?
     static let type = "SetValueAction"
 
-    init (_ value: Int) {
+    init (_ value: Int?) {
         self.value = value
     }
 
     init(_ standardAction: StandardAction) {
-        self.value = standardAction.payload!["value"] as! Int
+        self.value = standardAction.payload!["value"] as! Int?
     }
 
     func toStandardAction() -> StandardAction {


### PR DESCRIPTION
This should resolve #265

Prior to this change new state was optional, which doesn’t match ReSwift’s requirement of always providing a state after the store is initialized.

The optional `newState` was leading to type-mismatches with subscribers that had an optional state.
