### PR TITLE
Removed superfluous “return” statements & made flow handling style consistent

### DIFF
--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -12,7 +12,7 @@ import ReSwift
 let firstMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
-            
+
             if var action = action as? SetValueStringAction {
                 action.value += " First Middleware"
                 next(action)
@@ -26,7 +26,7 @@ let firstMiddleware: Middleware<StateType> = { dispatch, getState in
 let secondMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
-            
+
             if var action = action as? SetValueStringAction {
                 action.value += " Second Middleware"
                 next(action)
@@ -40,11 +40,11 @@ let secondMiddleware: Middleware<StateType> = { dispatch, getState in
 let dispatchingMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in
         return { action in
-            
+
             if var action = action as? SetValueAction {
                 dispatch(SetValueStringAction("\(action.value ?? 0)"))
             }
-            
+
             next(action)
         }
     }
@@ -53,15 +53,15 @@ let dispatchingMiddleware: Middleware<StateType> = { dispatch, getState in
 let stateAccessingMiddleware: Middleware<TestStringAppState> = { dispatch, getState in
     return { next in
         return { action in
-            
+
             let appState = getState(),
-            stringAction = action as? SetValueStringAction
-            
+                stringAction = action as? SetValueStringAction
+
             // avoid endless recursion by checking if we've dispatched exactly this action
             if appState?.testValue == "OK" && stringAction?.value != "Not OK" {
                 // dispatch a new action
                 dispatch(SetValueStringAction("Not OK"))
-                
+
                 // and swallow the current one
                 next(NoOpAction())
             } else {
@@ -73,43 +73,43 @@ let stateAccessingMiddleware: Middleware<TestStringAppState> = { dispatch, getSt
 
 // swiftlint:disable function_body_length
 class StoreMiddlewareTests: XCTestCase {
-    
+
     /**
      it can decorate dispatch function
      */
     func testDecorateDispatch() {
         let reducer = TestValueStringReducer()
         let store = Store<TestStringAppState>(reducer: reducer.handleAction,
-                                              state: TestStringAppState(),
-                                              middleware: [firstMiddleware, secondMiddleware])
-        
+            state: TestStringAppState(),
+            middleware: [firstMiddleware, secondMiddleware])
+
         let subscriber = TestStoreSubscriber<TestStringAppState>()
         store.subscribe(subscriber)
-        
+
         let action = SetValueStringAction("OK")
         store.dispatch(action)
-        
+
         XCTAssertEqual(store.state.testValue, "OK First Middleware Second Middleware")
     }
-    
+
     /**
      it can dispatch actions
      */
     func testCanDispatch() {
         let reducer = TestValueStringReducer()
         let store = Store<TestStringAppState>(reducer: reducer.handleAction,
-                                              state: TestStringAppState(),
-                                              middleware: [firstMiddleware, secondMiddleware, dispatchingMiddleware])
-        
+            state: TestStringAppState(),
+            middleware: [firstMiddleware, secondMiddleware, dispatchingMiddleware])
+
         let subscriber = TestStoreSubscriber<TestStringAppState>()
         store.subscribe(subscriber)
-        
+
         let action = SetValueAction(10)
         store.dispatch(action)
-        
+
         XCTAssertEqual(store.state.testValue, "10 First Middleware Second Middleware")
     }
-    
+
     /**
      it middleware can access the store's state
      */
@@ -117,12 +117,12 @@ class StoreMiddlewareTests: XCTestCase {
         let reducer = TestValueStringReducer()
         var state = TestStringAppState()
         state.testValue = "OK"
-        
+
         let store = Store<TestStringAppState>(reducer: reducer.handleAction, state: state,
-                                              middleware: [stateAccessingMiddleware])
-        
+            middleware: [stateAccessingMiddleware])
+
         store.dispatch(SetValueStringAction("Action That Won't Go Through"))
-        
+
         XCTAssertEqual(store.state.testValue, "Not OK")
     }
 }


### PR DESCRIPTION
These are purely stylistic changes for improved clarity.

#### Cleanup of superfluous return statements

Currently, in StoreMiddlewareTests.swift, we `return next(action)` in several spots, despite the fact `next(action)` always returns `Void`. In this commit, these superfluous returns are removed, to improve clarity.

#### Consistency of flow handling

In most places, if/else was used to enforce proper execution flow inside the `Middleware` closures where one of two `DispatchFunction` arguments gets called before returning. Removing the superfluous return statements has required that if/else also be used in one more place, which ends up making the code more consistent. 

Specifically, we have been relying on a `return` statement to avoid calling a subsequent DispatchFunction in `stateAccessingMiddleware`, whereas in `firstMiddleware` and `secondMiddleware`, we have been relying upon an `else` statement. In this commit, `stateAccessingMiddleware` now uses an `else` like the other two, improving clarity. 