### PR TITLE
Fix retain cycle in SubscriptionBox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - osx_image: xcode8.3
       env: SCHEME="macOS"  SDK="macosx10.12"          DESTINATION="arch=x86_64"
     - osx_image: xcode8.3
-      env: SCHEME="iOS"    SDK="iphonesimulator10.3"  DESTINATION="OS=10.3,name=iPhone 6S Plus"
+      env: SCHEME="iOS"    SDK="iphonesimulator10.3"  DESTINATION="OS=10.3.1,name=iPhone 6S Plus"
     - osx_image: xcode8.3
       env: SCHEME="tvOS"   SDK="appletvsimulator10.2"  DESTINATION="OS=10.2,name=Apple TV 1080p"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ env:
 
 matrix:
   include:
-    - osx_image: xcode8.2
+    - osx_image: xcode8.3
       env: SCHEME="macOS"  SDK="macosx10.12"          DESTINATION="arch=x86_64"
-    - osx_image: xcode8.2
+    - osx_image: xcode8.3
       env: SCHEME="iOS"    SDK="iphonesimulator10.2"  DESTINATION="OS=10.1,name=iPhone 6S Plus"
-    - osx_image: xcode8.2
+    - osx_image: xcode8.3
       env: SCHEME="tvOS"   SDK="appletvsimulator10.1"  DESTINATION="OS=10.1,name=Apple TV 1080p"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
     - osx_image: xcode8.3
       env: SCHEME="macOS"  SDK="macosx10.12"          DESTINATION="arch=x86_64"
     - osx_image: xcode8.3
-      env: SCHEME="iOS"    SDK="iphonesimulator10.2"  DESTINATION="OS=10.1,name=iPhone 6S Plus"
+      env: SCHEME="iOS"    SDK="iphonesimulator10.3"  DESTINATION="OS=10.3,name=iPhone 6S Plus"
     - osx_image: xcode8.3
-      env: SCHEME="tvOS"   SDK="appletvsimulator10.1"  DESTINATION="OS=10.1,name=Apple TV 1080p"
+      env: SCHEME="tvOS"   SDK="appletvsimulator10.2"  DESTINATION="OS=10.2,name=Apple TV 1080p"
 
 script:
   - set -o pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
+- Fix retain cycle in SubscriptionBox (#278) - @mjarvis, @DivineDominion
 
 # 4.0.0
 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -125,7 +125,11 @@ open class Store<State: StateType>: StoreType {
         subscriber: AnyStoreSubscriber
         ) -> SubscriptionBox<State> {
 
-        return SubscriptionBox(originalSubscription: originalSubscription, transformedSubscription: transformedSubscription, subscriber: subscriber)
+        return SubscriptionBox(
+            originalSubscription: originalSubscription,
+            transformedSubscription: transformedSubscription,
+            subscriber: subscriber
+        )
     }
 
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -38,7 +38,7 @@ class SubscriptionBox<State> {
         // If we haven't received a transformed subscription, we forward all values
         // from the original subscription.
         } else {
-            originalSubscription.observe { _, newState in
+            originalSubscription.observe { [unowned self] _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         }

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -32,7 +32,7 @@ class SubscriptionBox<State> {
         // If we received a transformed subscription, we subscribe to that subscription
         // and forward all new values to the subscriber.
         if let transformedSubscription = transformedSubscription {
-            transformedSubscription.observe { _, newState in
+            transformedSubscription.observe { [unowned self] _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         // If we haven't received a transformed subscription, we forward all values

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -193,7 +193,11 @@ fileprivate class TestStore<State: StateType>: Store<State> {
         originalSubscription: Subscription<State>,
         transformedSubscription: Subscription<T>?,
         subscriber: AnyStoreSubscriber) -> SubscriptionBox<State> {
-        return TestSubscriptionBox(originalSubscription: originalSubscription, transformedSubscription: transformedSubscription, subscriber: subscriber)
+        return TestSubscriptionBox(
+            originalSubscription: originalSubscription,
+            transformedSubscription: transformedSubscription,
+            subscriber: subscriber
+        )
     }
 }
 
@@ -216,7 +220,7 @@ extension StoreSubscriptionTests {
 
                 store.subscribe(subscriber)
                 XCTAssertEqual(subscriber.receivedStates.count, 1)
-                let subscriptionBox: TestSubscriptionBox<TestAppState> = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
+                let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
                 subscriptionBox.didDeinit = { didDeinit = true }
 
                 store.dispatch(TracerAction())
@@ -227,10 +231,10 @@ extension StoreSubscriptionTests {
             XCTAssertEqual(store.subscriptions.count, 0)
             store.dispatch(TracerAction())
             XCTAssertEqual(subscriber.receivedStates.count, 2)
-            
+
             store = nil
         }
-        
+
         XCTAssertTrue(didDeinit)
     }
 
@@ -253,7 +257,7 @@ extension StoreSubscriptionTests {
                     $0.select({ $0.testValue })
                 })
                 XCTAssertEqual(subscriber.receivedStates.count, 1)
-                let subscriptionBox: TestSubscriptionBox<TestAppState> = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
+                let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
                 subscriptionBox.didDeinit = { didDeinit = true }
 
                 store.dispatch(TracerAction())
@@ -264,10 +268,10 @@ extension StoreSubscriptionTests {
             XCTAssertEqual(store.subscriptions.count, 0)
             store.dispatch(TracerAction())
             XCTAssertEqual(subscriber.receivedStates.count, 2)
-            
+
             store = nil
         }
-        
+
         XCTAssertTrue(didDeinit)
     }
 }


### PR DESCRIPTION
`SubscriptionBox` retains `originalSubscription`, which was retaining `self` in the observe closure.

We can safely make this `[unowned self]` since `SubscriptionBox` is the only object that holds a reference to `originalSubscription` (it is discarded in the `Store` function that creates the box)