### PR TITLE
Readme swift4

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ class CounterViewController: UIViewController, StoreSubscriber {
         counterLabel.text = "\(state.counter)"
     }
 
-    @IBAction func increaseButtonTapped(sender: UIButton) {
+    @IBAction func increaseButtonTapped(_ sender: UIButton) {
         mainStore.dispatch(
             CounterActionIncrease()
         )
     }
 
-    @IBAction func decreaseButtonTapped(sender: UIButton) {
+    @IBAction func decreaseButtonTapped(_ sender: UIButton) {
         mainStore.dispatch(
             CounterActionDecrease()
         )

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ class CounterViewController: UIViewController, StoreSubscriber {
 
     @IBOutlet var counterLabel: UILabel!
 
-    override func viewWillAppear(animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         mainStore.subscribe(self)
     }
 
-    override func viewWillDisappear(animated: Bool) {
+    override func viewWillDisappear(_ animated: Bool) {
         mainStore.unsubscribe(self)
     }
 


### PR DESCRIPTION
Since Swift3, some UIKit methods had the first parameter label removed from the method signature, so I've updated the example contained in the `README.md` to be consistent with this change.