### PR TITLE
Add important bug fix to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Fix retain cycle in SubscriptionBox (#278) - @mjarvis, @DivineDominion
+- Fix bug where using skipRepeats with optional substate would not notify when the substate became nil [#55655](https://github.com/ReSwift/ReSwift/commit/55655098889ccb9adb716403544926dea8e79682) - @Ben-G
 
 # 4.0.0
 


### PR DESCRIPTION
In https://github.com/ReSwift/ReSwift/commit/55655098889ccb9adb716403544926dea8e79682 @Ben-G fixed a very important bug.
The bug would cause `newState` to not be called when a selected substate went from non-nil to nil.