### PR TITLE
Fix retain cycle in SubscriptionBox (#278)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ env:
 
 matrix:
   include:
-    - osx_image: xcode8.2
+    - osx_image: xcode8.3
       env: SCHEME="macOS"  SDK="macosx10.12"          DESTINATION="arch=x86_64"
-    - osx_image: xcode8.2
-      env: SCHEME="iOS"    SDK="iphonesimulator10.2"  DESTINATION="OS=10.1,name=iPhone 6S Plus"
-    - osx_image: xcode8.2
-      env: SCHEME="tvOS"   SDK="appletvsimulator10.1"  DESTINATION="OS=10.1,name=Apple TV 1080p"
+    - osx_image: xcode8.3
+      env: SCHEME="iOS"    SDK="iphonesimulator10.3"  DESTINATION="OS=10.3.1,name=iPhone 6S Plus"
+    - osx_image: xcode8.3
+      env: SCHEME="tvOS"   SDK="appletvsimulator10.2"  DESTINATION="OS=10.2,name=Apple TV 1080p"
 
 script:
   - set -o pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix retain cycle in SubscriptionBox (#278) - @mjarvis, @DivineDominion
+
 # 4.0.0
 
 *Work in Progress*

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -88,7 +88,7 @@ open class Store<State: StateType>: StoreType {
         // the subscription, e.g. in order to subselect parts of the store's state.
         let transformedSubscription = transform?(originalSubscription)
 
-        let subscriptionBox = SubscriptionBox(
+        let subscriptionBox = self.subscriptionBox(
             originalSubscription: originalSubscription,
             transformedSubscription: transformedSubscription,
             subscriber: subscriber
@@ -99,6 +99,19 @@ open class Store<State: StateType>: StoreType {
         if let state = self.state {
             originalSubscription.newValues(oldState: nil, newState: state)
         }
+    }
+
+    internal func subscriptionBox<T>(
+        originalSubscription: Subscription<State>,
+        transformedSubscription: Subscription<T>?,
+        subscriber: AnyStoreSubscriber
+        ) -> SubscriptionBox<State> {
+
+        return SubscriptionBox(
+            originalSubscription: originalSubscription,
+            transformedSubscription: transformedSubscription,
+            subscriber: subscriber
+        )
     }
 
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -32,13 +32,13 @@ class SubscriptionBox<State> {
         // If we received a transformed subscription, we subscribe to that subscription
         // and forward all new values to the subscriber.
         if let transformedSubscription = transformedSubscription {
-            transformedSubscription.observe { _, newState in
+            transformedSubscription.observe { [unowned self] _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         // If we haven't received a transformed subscription, we forward all values
         // from the original subscription.
         } else {
-            originalSubscription.observe { _, newState in
+            originalSubscription.observe { [unowned self] _, newState in
                 self.subscriber?._newState(state: newState as Any)
             }
         }

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -28,7 +28,7 @@ class StoreSubscriptionTests: XCTestCase {
     /**
      It does not strongly capture an observer
      */
-    func testStrongCapture() {
+    func testDoesNotCaptureStrongly() {
         store = Store(reducer: reducer.handleAction, state: TestAppState())
         var subscriber: TestSubscriber? = TestSubscriber()
 
@@ -164,5 +164,114 @@ class StoreSubscriptionTests: XCTestCase {
         store.subscribe(subscriber) { $0 }
 
         XCTAssertEqual(store.subscriptions.count, 1)
+    }
+}
+
+// MARK: Retain Cycle Detection
+
+fileprivate struct TracerAction: Action { }
+
+fileprivate class TestSubscriptionBox<S>: SubscriptionBox<S> {
+    override init<T>(
+        originalSubscription: Subscription<S>,
+        transformedSubscription: Subscription<T>?,
+        subscriber: AnyStoreSubscriber
+        ) {
+        super.init(originalSubscription: originalSubscription,
+                   transformedSubscription: transformedSubscription,
+                   subscriber: subscriber)
+    }
+
+    var didDeinit: (() -> Void)?
+    deinit {
+        didDeinit?()
+    }
+}
+
+fileprivate class TestStore<State: StateType>: Store<State> {
+    override func subscriptionBox<T>(
+        originalSubscription: Subscription<State>,
+        transformedSubscription: Subscription<T>?,
+        subscriber: AnyStoreSubscriber) -> SubscriptionBox<State> {
+        return TestSubscriptionBox(
+            originalSubscription: originalSubscription,
+            transformedSubscription: transformedSubscription,
+            subscriber: subscriber
+        )
+    }
+}
+
+extension StoreSubscriptionTests {
+
+    func testRetainCycle_OriginalSubscription() {
+
+        var didDeinit = false
+
+        autoreleasepool {
+
+            store = TestStore(reducer: reducer.handleAction, state: TestAppState())
+            let subscriber: TestSubscriber = TestSubscriber()
+
+            // Preconditions
+            XCTAssertEqual(subscriber.receivedStates.count, 0)
+            XCTAssertEqual(store.subscriptions.count, 0)
+
+            autoreleasepool {
+
+                store.subscribe(subscriber)
+                XCTAssertEqual(subscriber.receivedStates.count, 1)
+                let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
+                subscriptionBox.didDeinit = { didDeinit = true }
+
+                store.dispatch(TracerAction())
+                XCTAssertEqual(subscriber.receivedStates.count, 2)
+                store.unsubscribe(subscriber)
+            }
+
+            XCTAssertEqual(store.subscriptions.count, 0)
+            store.dispatch(TracerAction())
+            XCTAssertEqual(subscriber.receivedStates.count, 2)
+
+            store = nil
+        }
+
+        XCTAssertTrue(didDeinit)
+    }
+
+    func testRetainCycle_TransformedSubscription() {
+
+        var didDeinit = false
+
+        autoreleasepool {
+
+            store = TestStore(reducer: reducer.handleAction, state: TestAppState())
+            let subscriber = TestStoreSubscriber<Int?>()
+
+            // Preconditions
+            XCTAssertEqual(subscriber.receivedStates.count, 0)
+            XCTAssertEqual(store.subscriptions.count, 0)
+
+            autoreleasepool {
+
+                store.subscribe(subscriber, transform: {
+                    $0.select({ $0.testValue })
+                })
+                XCTAssertEqual(subscriber.receivedStates.count, 1)
+                let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>
+                subscriptionBox.didDeinit = { didDeinit = true }
+
+                store.dispatch(TracerAction())
+                XCTAssertEqual(subscriber.receivedStates.count, 2)
+                store.unsubscribe(subscriber)
+            }
+
+            XCTAssertEqual(store.subscriptions.count, 0)
+            store.dispatch(TracerAction())
+            XCTAssertEqual(subscriber.receivedStates.count, 2)
+
+            store = nil
+        }
+
+        XCTAssertTrue(didDeinit)
     }
 }


### PR DESCRIPTION
* Fix retain cycle in SubscriptionBox

`SubscriptionBox` retains `originalSubscription`, which was retaining `self` in the observe closure.

We can safely make this `[unowned self]` since `SubscriptionBox` is the only object that holds a reference to `originalSubscription` (it is discarded in the `Store` function that creates the box)

* add SubscriptionBox factory as testing seam

* add test to verify the subscription is retained

* add closure retain cycle test for transformation

* Fix second retain cycle in SubscriptionBox

`SubscriptionBox` retains `originalSubscription`, which retains the transformed subscription, which was retaining `self` in the observe block, completing the cycle back to `SubscriptionBox`

We can safely make this `[unowned self]` since `SubscriptionBox` is the only object that holds a reference to `originalSubscription` (it is discarded in the `Store` function that creates the box).

* Update Travis CI image to Xcode 8.3

Resolves a compiler segfault in `StoreSubscriptionTests.swift`

* Update changelog