### PR TITLE
Fix compilation in Swift 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ env:
 matrix:
   include:
     - osx_image: xcode9
-      env: SCHEME="macOS"  SDK="macosx10.13"          DESTINATION="arch=x86_64"
+      env: SCHEME="macOS"  SDK="macosx10.13"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
     - osx_image: xcode9
-      env: SCHEME="iOS"    SDK="iphonesimulator11.0"  DESTINATION="OS=11.0,name=iPhone 8"
+      env: SCHEME="macOS"  SDK="macosx10.13"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.0"
     - osx_image: xcode9
-      env: SCHEME="tvOS"   SDK="appletvsimulator11.0"  DESTINATION="OS=11.0,name=Apple TV 1080p"
+      env: SCHEME="iOS"    SDK="iphonesimulator11.0"  DESTINATION="OS=11.0,name=iPhone 8"          SWIFT_VERSION="4.0"
+    - osx_image: xcode9
+      env: SCHEME="tvOS"   SDK="appletvsimulator11.0"  DESTINATION="OS=11.0,name=Apple TV 1080p"   SWIFT_VERSION="4.0"
 
 script:
   - set -o pipefail
@@ -36,6 +38,7 @@ script:
     ONLY_ACTIVE_ARCH=YES
     GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
     GCC_GENERATE_TEST_COVERAGE_FILES=YES
+    SWIFT_VERSION=$SWIFT_VERSION
     test
 
 after_success:

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -85,7 +85,7 @@ open class Store<State: StateType>: StoreType {
         }
     }
 
-    private func _subscribe<SelectedState, S: StoreSubscriber>(
+    fileprivate func _subscribe<SelectedState, S: StoreSubscriber>(
         _ subscriber: S, originalSubscription: Subscription<State>,
         transformedSubscription: Subscription<SelectedState>?)
         where S.StoreSubscriberStateType == SelectedState


### PR DESCRIPTION
In Swift 3, `private` is not accessible to extensions within the same file, so we need to mark this as `fileprivate` instead.

This fixes a bug introduced since the last release so there is no need to add it to the changelog