### PR TITLE
[Release] 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
+
+# 4.0.1
+
+*Released: 12/19/2017*
+
+**Other:**
+
 - Fix retain cycle in SubscriptionBox (#278) - @mjarvis, @DivineDominion
-- Fix bug where using skipRepeats with optional substate would not notify when the substate became nil [#55655](https://github.com/ReSwift/ReSwift/commit/55655098889ccb9adb716403544926dea8e79682) - @Ben-G
+- Fix bug where using skipRepeats with optional substate would not notify when the substate became nil https://github.com/ReSwift/ReSwift/commit/55655098889ccb9adb716403544926dea8e79682 - @Ben-G
 - Add automatic skipRepeats for Equatable substate selection (#300) - @JoeCherry
 
 # 4.0.0

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReSwift"
-  s.version          = "4.0.0"
+  s.version          = "4.0.1"
   s.summary          = "Unidirectional Data Flow in Swift"
   s.description      = <<-DESC
                         ReSwift is a Redux-like implementation of the unidirectional data flow architecture in Swift.

--- a/ReSwift/Info.plist
+++ b/ReSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This brings over version & changelog information from the 4.0.1 release, which was tagged off of a separate branch to which we cherry-picked bug fixes.