### PR TITLE
Improve subscription & state update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
+- Improve subscription & state update performance (#325) - @mjarvis
 
 # 4.0.1
 

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -90,6 +90,9 @@
 		D47D2D571E32C4170064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
 		D47D2D581E32C4180064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
 		D47D2D591E32C4190064769E /* DispatchingStoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */; };
+		D490BC43203F291800902589 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D490BC41203F27E000902589 /* PerformanceTests.swift */; };
+		D490BC44203F291900902589 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D490BC41203F27E000902589 /* PerformanceTests.swift */; };
+		D490BC45203F291A00902589 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D490BC41203F27E000902589 /* PerformanceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -162,6 +165,7 @@
 		8DA430622E3D093002316DB5 /* Pods-SwiftLintIntegration.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.debug.xcconfig"; sourceTree = "<group>"; };
 		B5C08F1806830A13C9006A27 /* libPods-SwiftLintIntegration.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SwiftLintIntegration.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D47D2D551E32C3F50064769E /* DispatchingStoreType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchingStoreType.swift; sourceTree = "<group>"; };
+		D490BC41203F27E000902589 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -289,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				625E669E1C1FFA3C0027C288 /* Info.plist */,
+				D490BC41203F27E000902589 /* PerformanceTests.swift */,
 				73F39F331D3EE3C300DFFE62 /* StoreDispatchTests.swift */,
 				259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */,
 				25AB3B7F1C54A79F00A41513 /* StoreSubscriberTests.swift */,
@@ -775,6 +780,7 @@
 				73723E061D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F3A1D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF741C30C34000D63A58 /* TypeHelperTests.swift in Sources */,
+				D490BC45203F291A00902589 /* PerformanceTests.swift in Sources */,
 				25DBCF751C30C34000D63A58 /* TestFakes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -810,6 +816,7 @@
 				73723E051D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F391D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF9F1C30C50000D63A58 /* TypeHelperTests.swift in Sources */,
+				D490BC44203F291900902589 /* PerformanceTests.swift in Sources */,
 				25DBCFA01C30C50000D63A58 /* TestFakes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -848,6 +855,7 @@
 				625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */,
 				73F39F341D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				25AB3B811C54A84500A41513 /* StoreSubscriberTests.swift in Sources */,
+				D490BC43203F291800902589 /* PerformanceTests.swift in Sources */,
 				259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */,
 				73E545DA1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
 				73723E041D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,

--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
@@ -11,9 +11,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.0046359</real>
+					<real>0.0067716</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Feb 22, 2018 at 09:34:33</string>
+					<string>Feb 22, 2018 at 09:35:57</string>
 				</dict>
 			</dict>
 			<key>testSubscribe()</key>
@@ -21,9 +21,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.18611</real>
+					<real>0.012891</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Feb 22, 2018 at 09:34:33</string>
+					<string>Feb 22, 2018 at 09:35:57</string>
 				</dict>
 			</dict>
 		</dict>

--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
@@ -11,9 +11,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.0067716</real>
+					<real>0.0031482</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Feb 22, 2018 at 09:35:57</string>
+					<string>Feb 22, 2018 at 09:53:25</string>
 				</dict>
 			</dict>
 			<key>testSubscribe()</key>
@@ -21,9 +21,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.012891</real>
+					<real>0.0087853</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Feb 22, 2018 at 09:35:57</string>
+					<string>Feb 22, 2018 at 09:53:25</string>
 				</dict>
 			</dict>
 		</dict>

--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/8A5AF011-A17C-4780-8B4D-183154BA1DDA.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>PerformanceTests</key>
+		<dict>
+			<key>testNotify()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0046359</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Feb 22, 2018 at 09:34:33</string>
+				</dict>
+			</dict>
+			<key>testSubscribe()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.18611</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Feb 22, 2018 at 09:34:33</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/Info.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>8A5AF011-A17C-4780-8B4D-183154BA1DDA</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro11,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -25,10 +25,15 @@ open class Store<State: StateType>: StoreType {
 
     /*private (set)*/ public var state: State! {
         didSet {
-            subscriptions = subscriptions.filter { $0.subscriber != nil }
+            var filtered = subscriptions
             subscriptions.forEach {
-                $0.newValues(oldState: oldValue, newState: state)
+                if $0.subscriber == nil {
+                    filtered.remove($0)
+                } else {
+                    $0.newValues(oldState: oldValue, newState: state)
+                }
             }
+            subscriptions = filtered
         }
     }
 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -36,7 +36,7 @@ open class Store<State: StateType>: StoreType {
 
     private var reducer: Reducer<State>
 
-    var subscriptions: [SubscriptionType] = []
+    var subscriptions: Set<SubscriptionType> = []
 
     private var isDispatching = false
 
@@ -90,19 +90,13 @@ open class Store<State: StateType>: StoreType {
         transformedSubscription: Subscription<SelectedState>?)
         where S.StoreSubscriberStateType == SelectedState
     {
-        // If the same subscriber is already registered with the store, replace the existing
-        // subscription with the new one.
-        if let index = subscriptions.index(where: { $0.subscriber === subscriber }) {
-            subscriptions.remove(at: index)
-        }
-
         let subscriptionBox = self.subscriptionBox(
             originalSubscription: originalSubscription,
             transformedSubscription: transformedSubscription,
             subscriber: subscriber
         )
 
-        subscriptions.append(subscriptionBox)
+        subscriptions.update(with: subscriptionBox)
 
         if let state = self.state {
             originalSubscription.newValues(oldState: nil, newState: state)

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -16,10 +16,15 @@ import Foundation
 ///
 /// The box subscribes either to the original subscription, or if available to the transformed
 /// subscription and passes any values that come through this subscriptions to the subscriber.
-class SubscriptionBox<State> {
+class SubscriptionBox<State>: Hashable {
 
     private let originalSubscription: Subscription<State>
     weak var subscriber: AnyStoreSubscriber?
+    private let objectIdentifier: ObjectIdentifier
+
+    var hashValue: Int {
+        return self.objectIdentifier.hashValue
+    }
 
     init<T>(
         originalSubscription: Subscription<State>,
@@ -28,6 +33,7 @@ class SubscriptionBox<State> {
     ) {
         self.originalSubscription = originalSubscription
         self.subscriber = subscriber
+        self.objectIdentifier = ObjectIdentifier(subscriber)
 
         // If we received a transformed subscription, we subscribe to that subscription
         // and forward all new values to the subscriber.
@@ -49,6 +55,10 @@ class SubscriptionBox<State> {
         // values of type `<State>`. If present, transformed subscriptions will
         // receive this update and transform it before passing it on to the subscriber.
         self.originalSubscription.newValues(oldState: oldState, newState: newState)
+    }
+
+    static func == (left: SubscriptionBox<State>, right: SubscriptionBox<State>) -> Bool {
+        return left.objectIdentifier == right.objectIdentifier
     }
 }
 

--- a/ReSwiftTests/PerformanceTests.swift
+++ b/ReSwiftTests/PerformanceTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import ReSwift
+
+final class PerformanceTests: XCTestCase {
+    struct MockState: StateType {}
+    struct MockAction: Action {}
+
+    let subscribers: [MockSubscriber] = (0..<3000).map { _ in MockSubscriber() }
+    let store = Store(
+        reducer: { _, state in return state ?? MockState() },
+        state: MockState(),
+        automaticallySkipsRepeats: false
+    )
+
+    class MockSubscriber: StoreSubscriber {
+        func newState(state: MockState) {
+            // Do nothing
+        }
+    }
+
+    func testNotify() {
+        self.subscribers.forEach(self.store.subscribe)
+        self.measure {
+            self.store.dispatch(MockAction())
+        }
+    }
+
+    func testSubscribe() {
+        self.measure {
+            self.subscribers.forEach(self.store.subscribe)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #324

See commit descriptions for details

TL;DR:
- testNotify(): 0.0046359 -> 0.0031482 (32% faster)
- testSubscribe(): 0.1861 -> 0.0087853 (95% faster)