### PR TITLE
(iOS only) Enable build settings "Allow app extension API only"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Improve subscription & state update performance (#325) - @mjarvis
+- Enable build settings "Allow app extension API only" (#328) - @oradyvan
 
 # 4.0.1
 

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -1205,6 +1205,7 @@
 		625E668C1C1FF97E0027C288 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -1221,6 +1222,7 @@
 		625E668D1C1FF97E0027C288 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Since I am working on an iOS app extension, I was planning to re-use part of our main app code that is using ReSwift library. To avoid the warnings about unsafe use of non-app extension API in the app extension I tried enable the build setting "Allow app extension API only" in the project (both Debug and Release configurations). Nothing else has changed, except for the fact I am now able to use ReSwift in any app extensions for iOS platform.

Here is the official list of APIs that cannot be used by ReSwift framework with these build settings enabled:
https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html#//apple_ref/doc/uid/TP40014214-CH2-SW6
As for me they all look really non-related to the functionality ReSwift framework provides so I expect no issues with that.

Here is related open issue for this change: https://github.com/ReSwift/ReSwift/issues/304