### PR TITLE
Fix disappearing subscription bug from #325

### DIFF
--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/CA98BC4B-4A03-4B07-BF9E-12C3F6A52195.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/CA98BC4B-4A03-4B07-BF9E-12C3F6A52195.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>PerformanceTests</key>
+		<dict>
+			<key>testNotify()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0027875</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Mar 20, 2018 at 18:22:42</string>
+				</dict>
+			</dict>
+			<key>testSubscribe()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0084305</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Mar 20, 2018 at 18:22:42</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/Info.plist
+++ b/ReSwift.xcodeproj/xcshareddata/xcbaselines/25DBCF861C30C4DB00D63A58.xcbaseline/Info.plist
@@ -28,6 +28,30 @@
 			<key>targetArchitecture</key>
 			<string>x86_64</string>
 		</dict>
+		<key>CA98BC4B-4A03-4B07-BF9E-12C3F6A52195</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2800</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro14,3</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -25,15 +25,13 @@ open class Store<State: StateType>: StoreType {
 
     /*private (set)*/ public var state: State! {
         didSet {
-            var filtered = subscriptions
             subscriptions.forEach {
                 if $0.subscriber == nil {
-                    filtered.remove($0)
+                    subscriptions.remove($0)
                 } else {
                     $0.newValues(oldState: oldValue, newState: state)
                 }
             }
-            subscriptions = filtered
         }
     }
 

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -169,7 +169,9 @@ class StoreSubscriptionTests: XCTestCase {
     func testNewStateModifyingSubscriptionsDoesNotDiscardNewSubscription() {
         // This was built as a failing test due to a bug introduced by #325
         // The bug occured by adding a subscriber during `newState`
-        // The bug was caused by creating a copy of `subscriptions` before calling `newState`, and then assigning that copy back to `subscriptions`, losing the mutation that occured during `newState`
+        // The bug was caused by creating a copy of `subscriptions` before calling
+        // `newState`, and then assigning that copy back to `subscriptions`, losing
+        // the mutation that occured during `newState`
 
         store = Store(reducer: reducer.handleAction, state: TestAppState())
 

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -169,6 +169,20 @@ class TestStoreSubscriber<T>: StoreSubscriber {
     }
 }
 
+class BlockSubscriber<S>: StoreSubscriber {
+    typealias StoreSubscriberStateType = S
+    private let block: (S) -> Void
+
+    init(block: @escaping (S) -> Void) {
+        self.block = block
+    }
+
+    func newState(state: S) {
+        self.block(state)
+    }
+}
+
+
 class DispatchingSubscriber: StoreSubscriber {
     var store: Store<TestAppState>
 

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -182,7 +182,6 @@ class BlockSubscriber<S>: StoreSubscriber {
     }
 }
 
-
 class DispatchingSubscriber: StoreSubscriber {
     var store: Store<TestAppState>
 


### PR DESCRIPTION
If a new subscriber was added in `newState` caused by a state change,
assigning `subscriptions = filtered` would then discard that new
subscription.

Since `subscriptions` is a value type, we're safe to mutate in the
`forEach`, so we can fix this bug by never holding a copy of subscriptions,
instead just mutating in-place. If we changed `subscriptions` to a
reference type we would need to enumerate a copy instead.

Performance tests match baselines within allowable margins for error.