### PR TITLE
Remove unnecessary imports

### DIFF
--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 /// All actions that want to be able to be dispatched to a store need to conform to this protocol
 /// Currently it is just a marker protocol with no requirements.
 public protocol Action { }

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 public typealias DispatchFunction = (Action) -> Void
 public typealias Middleware<State> = (@escaping DispatchFunction, @escaping () -> State?)
     -> (@escaping DispatchFunction) -> DispatchFunction

--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -6,7 +6,5 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 public typealias Reducer<ReducerStateType> =
     (_ action: Action, _ state: ReducerStateType?) -> ReducerStateType

--- a/ReSwift/CoreTypes/State.swift
+++ b/ReSwift/CoreTypes/State.swift
@@ -6,6 +6,4 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 public protocol StateType { }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 DigiTales. All rights reserved.
 //
 
-import Foundation
-
 /**
  This class is the default implementation of the `Store` protocol. You will use this store in most
  of your applications. You shouldn't need to implement your own store.

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 public protocol AnyStoreSubscriber: class {
     // swiftlint:disable:next identifier_name
     func _newState(state: Any)

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 DigiTales. All rights reserved.
 //
 
-import Foundation
-
 /**
  Defines the interface of Stores in ReSwift. `Store` is the default implementation of this
  interface. Applications have a single store that stores the entire application state.

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Benjamin Encz. All rights reserved.
 //
 
-import Foundation
-
 /// A box around subscriptions and subscribers.
 ///
 /// Acts as a type-erasing wrapper around a subscription and its transformed subscription.

--- a/ReSwift/Utils/Coding.swift
+++ b/ReSwift/Utils/Coding.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 DigiTales. All rights reserved.
 //
 
-import Foundation
-
 public protocol Coding {
     init?(dictionary: [String: AnyObject])
     var dictionaryRepresentation: [String: AnyObject] { get }

--- a/ReSwift/Utils/TypeHelper.swift
+++ b/ReSwift/Utils/TypeHelper.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 DigiTales. All rights reserved.
 //
 
-import Foundation
-
 /**
  Method is only used internally in ReSwift to cast the generic `StateType` to a specific
  type expected by reducers / store subscribers.


### PR DESCRIPTION
Most files doesn't use symbols from `Foundation`, the imports,
therefore, are unnecessary.