### PR TITLE
Refactor newState() to apply(state:)

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -200,11 +200,11 @@ After the `appReducer` has called all of the sub-reducer functions, we have a ne
 
 ## Store Subscribers
 
-Store subscribers are types that are interested in receiving state updates from a store. Whenever the store updates its state it will notify all subscribers by calling the `newState` method on them. Subscribers need to conform to the `StoreSubscriber` protocol:
+Store subscribers are types that are interested in receiving state updates from a store. Whenever the store updates its state it will notify all subscribers by calling the `apply(state:)` method on them. Subscribers need to conform to the `StoreSubscriber` protocol:
 
 ```swift
 protocol StoreSubscriber {
-    func newState(state: StoreSubscriberStateType)
+    func apply(state: StoreSubscriberStateType)
 }
 ```
 
@@ -232,7 +232,7 @@ override func viewWillDisappear(animated: Bool) {
 }
 
 // The `state` argument needs to match the selected substate
-func newState(state: Response<[Repository]>?) {
+func apply(state: Response<[Repository]>?) {
     if case let .Success(repositories) = state {
         dataSource?.array = repositories
         tableView.reloadData()
@@ -241,9 +241,9 @@ func newState(state: Response<[Repository]>?) {
 ```
 In the example above we only select a single property from the overall application state: a network `Response` with a list of repositories.
 
-When selecting a substate as part of calling the `subscribe` method, you need to make sure that the argument of the `newState` method has the same type as whatever you return from the state subselection in the `subscribe` method.
+When selecting a substate as part of calling the `subscribe` method, you need to make sure that the argument of the `apply(state:)` method has the same type as whatever you return from the state subselection in the `subscribe` method.
 
-When subscribing within a ViewController you will typically update the view from within the `newState` method.
+When subscribing within a ViewController you will typically update the view from within the `apply(state:)` method.
 
 ## Example With Skipping Identical State Update
 

--- a/Docs/Stores.md
+++ b/Docs/Stores.md
@@ -1,8 +1,8 @@
-Store subscribers are types that are interested in receiving state updates from a store. Whenever the store updates its state it will notify all subscribers by calling the `newState` method on them. Subscribers need to conform to the `StoreSubscriber` protocol:
+Store subscribers are types that are interested in receiving state updates from a store. Whenever the store updates its state it will notify all subscribers by calling the `apply(state:)` method on them. Subscribers need to conform to the `StoreSubscriber` protocol:
 
 ```swift
 protocol StoreSubscriber {
-    func newState(state: StoreSubscriberStateType)
+    func apply(state: StoreSubscriberStateType)
 }
 ```
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - SwiftLint
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - SwiftLint
+
 SPEC CHECKSUMS:
   SwiftLint: 1134786caedd2caab0560d2f36b76414a5a56808
 
 PODFILE CHECKSUM: 937d436496e317ef5f238fab841c0529d8f5d201
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ class CounterViewController: UIViewController, StoreSubscriber {
         mainStore.unsubscribe(self)
     }
 
-    func newState(state: AppState) {
+    func apply(state: AppState) {
         counterLabel.text = "\(state.counter)"
     }
 
@@ -129,7 +129,7 @@ class CounterViewController: UIViewController, StoreSubscriber {
 }
 ```
 
-The `newState` method will be called by the `Store` whenever a new app state is available, this is where we need to adjust our view to reflect the latest app state.
+The `apply(state:)` method will be called by the `Store` whenever a new app state is available, this is where we need to adjust our view to reflect the latest app state.
 
 Button taps result in dispatched actions that will be handled by the store and its reducers, resulting in a new app state.
 

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -476,8 +476,6 @@
 				3F13C0E41E7B3E4000D8442C /* Sources */,
 				3F13C0E51E7B3E4000D8442C /* Frameworks */,
 				3F13C0E61E7B3E4000D8442C /* Resources */,
-				C6C5ED535A5FCEB5648419A2 /* [CP] Embed Pods Frameworks */,
-				3BED8D2D43A452D599C2F312 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -651,21 +649,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BED8D2D43A452D599C2F312 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		6012A4D4990919B303E1357A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -711,21 +694,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/BuildPhases/run-swiftlint\"";
-		};
-		C6C5ED535A5FCEB5648419A2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ReSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ReSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -8,20 +8,20 @@
 
 public protocol AnyStoreSubscriber: class {
     // swiftlint:disable:next identifier_name
-    func _newState(state: Any)
+    func _apply(state: Any)
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {
     associatedtype StoreSubscriberStateType
 
-    func newState(state: StoreSubscriberStateType)
+    func apply(state: StoreSubscriberStateType)
 }
 
 extension StoreSubscriber {
     // swiftlint:disable:next identifier_name
-    public func _newState(state: Any) {
+    public func _apply(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
-            newState(state: typedState)
+            apply(state: typedState)
         }
     }
 }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -27,7 +27,7 @@ public protocol StoreType: DispatchingStoreType {
 
     /**
      Subscribes the provided subscriber to this store.
-     Subscribers will receive a call to `newState` whenever the
+     Subscribers will receive a call to `apply(state:)` whenever the
      state in this store changes.
 
      - parameter subscriber: Subscriber that will receive store updates
@@ -37,7 +37,7 @@ public protocol StoreType: DispatchingStoreType {
 
     /**
      Subscribes the provided subscriber to this store.
-     Subscribers will receive a call to `newState` whenever the
+     Subscribers will receive a call to `apply(state:)` whenever the
      state in this store changes and the subscription decides to forward
      state update.
 

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -37,13 +37,13 @@ class SubscriptionBox<State>: Hashable {
         // and forward all new values to the subscriber.
         if let transformedSubscription = transformedSubscription {
             transformedSubscription.observe { [unowned self] _, newState in
-                self.subscriber?._newState(state: newState as Any)
+                self.subscriber?._apply(state: newState as Any)
             }
         // If we haven't received a transformed subscription, we forward all values
         // from the original subscription.
         } else {
             originalSubscription.observe { [unowned self] _, newState in
-                self.subscriber?._newState(state: newState as Any)
+                self.subscriber?._apply(state: newState as Any)
             }
         }
     }

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -49,7 +49,7 @@ class AutomaticallySkipRepeatsTests: XCTestCase {
 }
 
 extension AutomaticallySkipRepeatsTests: StoreSubscriber {
-    func newState(state: String) {
+    func apply(state: String) {
         subscriptionUpdates += 1
     }
 }

--- a/ReSwiftTests/PerformanceTests.swift
+++ b/ReSwiftTests/PerformanceTests.swift
@@ -13,7 +13,7 @@ final class PerformanceTests: XCTestCase {
     )
 
     class MockSubscriber: StoreSubscriber {
-        func newState(state: MockState) {
+        func apply(state: MockState) {
             // Do nothing
         }
     }

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -81,7 +81,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueAction(3))
 
         XCTAssertEqual(subscriber.receivedValue, 3)
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 
     /**
@@ -103,7 +103,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueStringAction("Initial"))
 
         XCTAssertEqual(subscriber.receivedValue, "Initial")
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 
     /**
@@ -125,7 +125,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetCustomSubstateAction(5))
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 
     func testPassesOnDuplicateSubstateUpdatesByDefault() {
@@ -143,7 +143,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetNonEquatableAction(NonEquatable()))
 
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
-        XCTAssertEqual(subscriber.newStateCallCount, 2)
+        XCTAssertEqual(subscriber.applyStateCallCount, 2)
     }
 
     func testPassesOnDuplicateSubstateWhenSkipsFalse() {
@@ -161,7 +161,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueStringAction("Initial"))
 
         XCTAssertEqual(subscriber.receivedValue, "Initial")
-        XCTAssertEqual(subscriber.newStateCallCount, 2)
+        XCTAssertEqual(subscriber.applyStateCallCount, 2)
     }
 
     func testSkipsStateUpdatesForEquatableStateByDefault() {
@@ -177,7 +177,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueStringAction("Initial"))
 
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 
     func testPassesOnDuplicateStateUpdatesInCustomizedStore() {
@@ -193,7 +193,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetValueStringAction("Initial"))
 
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
-        XCTAssertEqual(subscriber.newStateCallCount, 2)
+        XCTAssertEqual(subscriber.applyStateCallCount, 2)
     }
 
     func testSkipWhen() {
@@ -212,7 +212,7 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetCustomSubstateAction(5))
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 
     func testOnlyWhen() {
@@ -231,29 +231,29 @@ class StoreSubscriberTests: XCTestCase {
         store.dispatch(SetCustomSubstateAction(5))
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)
-        XCTAssertEqual(subscriber.newStateCallCount, 1)
+        XCTAssertEqual(subscriber.applyStateCallCount, 1)
     }
 }
 
 class TestFilteredSubscriber<T>: StoreSubscriber {
     var receivedValue: T!
-    var newStateCallCount = 0
+    var applyStateCallCount = 0
 
-    func newState(state: T) {
+    func apply(state: T) {
         receivedValue = state
-        newStateCallCount += 1
+        applyStateCallCount += 1
     }
 
 }
 
 /**
  Example of how you can select a substate. The return value from
- `selectSubstate` and the argument for `newState` need to match up.
+ `selectSubstate` and the argument for `apply(state:)` need to match up.
  */
 class TestSelectiveSubscriber: StoreSubscriber {
     var receivedValue: (Int?, String?)
 
-    func newState(state: (Int?, String?)) {
+    func apply(state: (Int?, String?)) {
         receivedValue = state
     }
 }

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -179,12 +179,12 @@ class StoreSubscriptionTests: XCTestCase {
         XCTAssertEqual(store.subscriptions.count, 1)
     }
 
-    func testNewStateModifyingSubscriptionsDoesNotDiscardNewSubscription() {
+    func testApplyStateModifyingSubscriptionsDoesNotDiscardNewSubscription() {
         // This was built as a failing test due to a bug introduced by #325
         // The bug occured by adding a subscriber during `newState`
         // The bug was caused by creating a copy of `subscriptions` before calling
-        // `newState`, and then assigning that copy back to `subscriptions`, losing
-        // the mutation that occured during `newState`
+        // `apply(state:)`, and then assigning that copy back to `subscriptions`, losing
+        // the mutation that occured during `apply(state:)`
 
         store = Store(reducer: reducer.handleAction, state: TestAppState())
 
@@ -222,8 +222,8 @@ class StoreSubscriptionTests: XCTestCase {
         }))
 
         // Have a subscriber (#1)
-        // #1 adds sub #2 in newState
-        // #1 dispatches in newState
+        // #1 adds sub #2 in apply(state:)
+        // #1 dispatches in apply(state:)
         // Test that store.subscribers == [#1, #2] // this should fail
     }
 }

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -164,7 +164,7 @@ struct TestNonEquatableReducer {
 class TestStoreSubscriber<T>: StoreSubscriber {
     var receivedStates: [T] = []
 
-    func newState(state: T) {
+    func apply(state: T) {
         receivedStates.append(state)
     }
 }
@@ -177,7 +177,7 @@ class BlockSubscriber<S>: StoreSubscriber {
         self.block = block
     }
 
-    func newState(state: S) {
+    func apply(state: S) {
         self.block(state)
     }
 }
@@ -189,7 +189,7 @@ class DispatchingSubscriber: StoreSubscriber {
         self.store = store
     }
 
-    func newState(state: TestAppState) {
+    func apply(state: TestAppState) {
         // Test if we've already dispatched this action to
         // avoid endless recursion
         if state.testValue != 5 {
@@ -206,7 +206,7 @@ class CallbackStoreSubscriber<T>: StoreSubscriber {
         self.handler = handler
     }
 
-    func newState(state: T) {
+    func apply(state: T) {
         handler(state)
     }
 }


### PR DESCRIPTION
Thanks so much for writing ReSwift!

Due to my personal baggage from languages of the past, a function named `newState()` is hard-wired in my brain to mean something like "Create and return a new state object".

This PR simply renames `newState()` to `apply(state:)`.

Feel free to merge if you think this is an improvement.  If not, no hard feelings 😁 