### PR TITLE
Remove internal access level control (because default is internal)

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -120,7 +120,7 @@ open class Store<State: StateType>: StoreType {
                    transformedSubscription: transformedSubscription)
     }
 
-    internal func subscriptionBox<T>(
+    func subscriptionBox<T>(
         originalSubscription: Subscription<State>,
         transformedSubscription: Subscription<T>?,
         subscriber: AnyStoreSubscriber

--- a/ReSwift/Utils/Assertions.swift
+++ b/ReSwift/Utils/Assertions.swift
@@ -15,7 +15,7 @@ import Foundation
  - parameter file:    Calling file
  - parameter line:    Calling line
  */
-internal func raiseFatalError(_ message: @autoclosure () -> String = "",
+func raiseFatalError(_ message: @autoclosure () -> String = "",
                               file: StaticString = #file, line: UInt = #line) -> Never {
     Assertions.fatalErrorClosure(message(), file, line)
     repeat {
@@ -25,8 +25,8 @@ internal func raiseFatalError(_ message: @autoclosure () -> String = "",
 
 /// Stores custom assertions closures, by default it points to Swift functions. But test target can
 /// override them.
-internal class Assertions {
-    internal static var fatalErrorClosure = swiftFatalErrorClosure
-    internal static let swiftFatalErrorClosure: (String, StaticString, UInt) -> Void
+class Assertions {
+    static var fatalErrorClosure = swiftFatalErrorClosure
+    static let swiftFatalErrorClosure: (String, StaticString, UInt) -> Void
         = { Swift.fatalError($0, file: $1, line: $2) }
 }

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 /**
- @testable import for internal testing of `Store.subscriptions`
+ @testable import for testing of `Store.subscriptions`
  */
 @testable import ReSwift
 

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 /**
- @testable import for internal testing of `withSpecificTypes`
+ @testable import for testing of `withSpecificTypes`
  */
 @testable import ReSwift
 

--- a/ReSwiftTests/XCTest+Assertions.swift
+++ b/ReSwiftTests/XCTest+Assertions.swift
@@ -7,7 +7,7 @@
 import Foundation
 import XCTest
 /**
- @testable import for internal testing of `Assertions.fatalErrorClosure`
+ @testable import for testing of `Assertions.fatalErrorClosure`
  */
 @testable import ReSwift
 

--- a/ReSwiftTests/XCTest+Compatibility.swift
+++ b/ReSwiftTests/XCTest+Compatibility.swift
@@ -1,21 +1,21 @@
 import XCTest
 
-internal func dispatchAsync(execute work: @escaping @convention(block) () -> Swift.Void) {
+func dispatchAsync(execute work: @escaping @convention(block) () -> Swift.Void) {
     DispatchQueue.global(qos: .default).async(execute: work)
 }
 
-internal func dispatchUserInitiatedAsync
+func dispatchUserInitiatedAsync
     (execute work: @escaping @convention(block) () -> Swift.Void) {
     DispatchQueue.global(qos: .userInitiated).async(execute: work)
 }
 
 extension XCTestCase {
 
-    internal func futureExpectation(withDescription description: String) -> XCTestExpectation {
+    func futureExpectation(withDescription description: String) -> XCTestExpectation {
         return expectation(description: description)
     }
 
-    internal func waitForFutureExpectations(
+    func waitForFutureExpectations(
         withTimeout timeout: TimeInterval,
         handler: XCWaitCompletionHandler? = nil) {
 


### PR DESCRIPTION
👻  Remove internal access level control (because default is internal)