### PR TITLE
Open Subscription to allow external extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Improve subscription & state update performance (#325) - @mjarvis
 - Enable build settings "Allow app extension API only" (#328) - @oradyvan
+- Open `Subscription<State>` to allow external extensions (#383) - @mjarvis
 
 # 4.0.1
 


### PR DESCRIPTION
Makes `observer` and `init(sink:)` publicly accessible on `Subscription<State>`.
This allows for ReSwift users to extend subscription to add additional skipping or mutation functionality.

I've also removed `func observe` and changed the code to directly assign to `observer` to make the closure ownership more clear.