### PR TITLE
add watchOS build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,17 @@ env:
 matrix:
   include:
     - osx_image: xcode9
-      env: SCHEME="macOS"  SDK="macosx10.13"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
+      env: SCHEME="macOS"    SDK="macosx10.13"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
     - osx_image: xcode9.3
-      env: SCHEME="macOS"  SDK="macosx10.13"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1"
-    - osx_image: xcode10
-      env: SCHEME="macOS"  SDK="macosx10.14"          DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2"
-    - osx_image: xcode10
-      env: SCHEME="iOS"    SDK="iphonesimulator12.0"  DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2"
-    - osx_image: xcode10
-      env: SCHEME="tvOS"   SDK="appletvsimulator12.0"  DESTINATION="OS=12.0,name=Apple TV 4K"      SWIFT_VERSION="4.2"
+      env: SCHEME="macOS"    SDK="macosx10.13"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1"
+    - osx_image: xcode10.1
+      env: SCHEME="macOS"    SDK="macosx10.14"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2"
+    - osx_image: xcode10.1
+      env: SCHEME="iOS"      SDK="iphonesimulator12.0"   DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2"
+    - osx_image: xcode10.1
+      env: SCHEME="tvOS"     SDK="appletvsimulator12.0"  DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2"
+    - osx_image: xcode10.1
+      env: SCHEME="watchOS"  SDK="watchsimulator5.1"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2"
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,9 @@ matrix:
     - osx_image: xcode10.1
       env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="iOS"      SDK="iphoneos"           DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
-    - osx_image: xcode10.1
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
     - osx_image: xcode10.1
-      env: SCHEME="watchOS"  SDK="watchos"            DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
-    - osx_image: xcode10.1
       env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
-    - osx_image: xcode10.1
-      env: SCHEME="tvOS"     SDK="appletvos"          DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,23 +17,24 @@ env:
 matrix:
   include:
     - osx_image: xcode9
-      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
+      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2" ACTION="test"
     - osx_image: xcode9.3
-      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1"
+      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2"
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2"
+      env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2"
+      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2"
+      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
 
 script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
   - xcodebuild
+    "$ACTION"
     -project "$FRAMEWORK_NAME.xcodeproj"
     -scheme "$FRAMEWORK_NAME-$SCHEME"
     -sdk "$SDK"
@@ -43,7 +44,6 @@ script:
     GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
     GCC_GENERATE_TEST_COVERAGE_FILES=YES
     SWIFT_VERSION=$SWIFT_VERSION
-    test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J ReSwift

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ env:
 matrix:
   include:
     - osx_image: xcode9
-      env: SCHEME="macOS"    SDK="macosx10.13"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
+      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2"
     - osx_image: xcode9.3
-      env: SCHEME="macOS"    SDK="macosx10.13"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1"
+      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1"
     - osx_image: xcode10.1
-      env: SCHEME="macOS"    SDK="macosx10.14"           DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2"
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2"
     - osx_image: xcode10.1
-      env: SCHEME="iOS"      SDK="iphonesimulator12.0"   DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2"
+      env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2"
     - osx_image: xcode10.1
-      env: SCHEME="tvOS"     SDK="appletvsimulator12.0"  DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2"
+      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2"
     - osx_image: xcode10.1
-      env: SCHEME="watchOS"  SDK="watchsimulator5.1"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2"
+      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2"
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,15 @@ matrix:
     - osx_image: xcode10.1
       env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
-      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
+      env: SCHEME="iOS"      SDK="iphoneos"           DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.1
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
+    - osx_image: xcode10.1
+      env: SCHEME="watchOS"  SDK="watchos"            DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
+    - osx_image: xcode10.1
+      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.1
+      env: SCHEME="tvOS"     SDK="appletvos"          DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
 
 script:
   - set -o pipefail


### PR DESCRIPTION
Previously, Travis CI didn't cover all supported ReSwift platforms.