### PR TITLE
remove deprecated 'returns' StoreType docs

### DIFF
--- a/ReSwift/CoreTypes/DispatchingStoreType.swift
+++ b/ReSwift/CoreTypes/DispatchingStoreType.swift
@@ -17,8 +17,6 @@ public protocol DispatchingStoreType {
      ```
 
      - parameter action: The action that is being dispatched to the store
-     - returns: By default returns the dispatched action, but middlewares can change the
-     return type, e.g. to return promises
      */
     func dispatch(_ action: Action)
 }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -88,9 +88,6 @@ public protocol StoreType: DispatchingStoreType {
      ```
      store.dispatch( noteActionCreatore.deleteNote(3) )
      ```
-
-     - returns: By default returns the dispatched action, but middlewares can change the
-     return type, e.g. to return promises
      */
     func dispatch(_ actionCreator: ActionCreator)
 


### PR DESCRIPTION
`dispatch` docstrings contained something about return values that do not apply anymore.