### PR TITLE
Deprecate `ActionCreator` and `AsyncActionCreator` (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
     - Removes the ability to directly set `state` by making it `private(set)`. This prevents users from bypassing reducers and middleware. All mutation of the state must occur through the normal `Action` & `Reducer` methods.
     - This deprecates the usage of `ReSwift-Recorder`. Changes may be made to that library in the future in order to support this change.
 
+- Deprecate `ActionCreator` and `AsyncActionCreator` (#391) - @mjarvis
+
+    - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk
+
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -161,16 +161,19 @@ open class Store<State: StateType>: StoreType {
         dispatchFunction(action)
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) {
         if let action = actionCreatorProvider(state, self) {
             dispatch(action)
         }
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ asyncActionCreatorProvider: @escaping AsyncActionCreator) {
         dispatch(asyncActionCreatorProvider, callback: nil)
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ actionCreatorProvider: @escaping AsyncActionCreator,
                        callback: DispatchCallback?) {
         actionCreatorProvider(state, self) { actionProvider in
@@ -185,8 +188,10 @@ open class Store<State: StateType>: StoreType {
 
     public typealias DispatchCallback = (State) -> Void
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     public typealias ActionCreator = (_ state: State, _ store: Store) -> Action?
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     public typealias AsyncActionCreator = (
         _ state: State,
         _ store: Store,

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -37,6 +37,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it accepts action creators
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testAcceptsActionCreators() {
         store.dispatch(SetValueAction(5))
 
@@ -52,6 +53,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it accepts async action creators
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testAcceptsAsyncActionCreators() {
 
         let asyncExpectation = futureExpectation(
@@ -85,6 +87,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it calls the callback once state update from async action is complete
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testCallsCalbackOnce() {
         let asyncExpectation = futureExpectation(withDescription:
             "It calls the callback once state update from async action is complete")


### PR DESCRIPTION
`ActionCreator` and `AsyncActionCreator` are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk