### PR TITLE
4.1 Release Candidate comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Upcoming
 
+**Breaking API Changes:**
+
+**API Changes:**
+
+**Other**
+
+# 4.1.0
+
+*Released: 03/21/2019*
+
 **API Changes:**
 - Deprecate `StandardAction` and `StandardActionConvertible` - @mjarvis
     
@@ -9,7 +19,7 @@
 
     - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk
 
-**Other**:
+**Other**
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Improve subscription & state update performance (#325) - @mjarvis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
     
     - These have been moved to https://github.com/ReSwift/ReSwift-Recorder since they are unnecessary for the base use of ReSwift
 
+- Deprecate `ActionCreator` and `AsyncActionCreator` (#391) - @mjarvis
+
+    - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk
+
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improve subscription & state update performance (#325) - @mjarvis
 - Enable build settings "Allow app extension API only" (#328) - @oradyvan
 - Open `Subscription<State>` to allow external extensions (#383) - @mjarvis
+- Update project to Swift 4.2 (#256, #335, #374) - @mjarvis, @DivineDominion
 
 # 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming
 
+**API Changes:**
+- Deprecate `StandardAction` and `StandardActionConvertible` - @mjarvis
+    
+    - These have been moved to https://github.com/ReSwift/ReSwift-Recorder since they are unnecessary for the base use of ReSwift
+
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@
     - The existence of `StandardAction` and `StandardActionConvertible` is somewhat confusing to new users, and does not have a direct use case within the core ReSwift library. Therefore, it has been moved to [ReSwift-Recorder](https://github.com/ReSwift/ReSwift-Recorder) where it belongs.
     - If you're using `StandardAction` in your project without `ReSwift-Recorder`, you can copy the old implementation into your project as a middle ground while you migrate away from its usage.
 
-- Make Store's state setter private (#354) - @mokagio
-
-    - Removes the ability to directly set `state` by making it `private(set)`. This prevents users from bypassing reducers and middleware. All mutation of the state must occur through the normal `Action` & `Reducer` methods.
-    - This deprecates the usage of `ReSwift-Recorder`. Changes may be made to that library in the future in order to support this change.
-
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Upcoming
 
-**Breaking API Changes:**
-- Remove `StandardAction` and `StandardActionConvertible` (#270) - @mjarvis
-    
-    - The existence of `StandardAction` and `StandardActionConvertible` is somewhat confusing to new users, and does not have a direct use case within the core ReSwift library. Therefore, it has been moved to [ReSwift-Recorder](https://github.com/ReSwift/ReSwift-Recorder) where it belongs.
-    - If you're using `StandardAction` in your project without `ReSwift-Recorder`, you can copy the old implementation into your project as a middle ground while you migrate away from its usage.
-
 **Other**:
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion

--- a/Docs/Actions.md
+++ b/Docs/Actions.md
@@ -5,3 +5,5 @@ In your ReSwift app you will define actions for every possible state change that
 Reducers handle these actions and implement state changes based on the information they provide.
 
 All actions in ReSwift conform to the `Action` protocol, which currently is just a marker protocol.
+
+You can either provide custom types as actions, or you can use the built in `StandardAction`.

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -130,13 +130,37 @@ Note that you don't need to store derived state inside of your app state. The ap
 
 Actions are used to express intended state changes. Actions don't contain functions. Instead, they provide information about the intended state change. For example, the user to be deleted in a `DeleteUser` action. In your ReSwift app you will define actions for every possible state change that can happen. Reducers handle these actions and implement state changes based on the information the actions provide. All actions in ReSwift conform to the `Action` protocol, which currently is just a marker protocol.
 
+You can either provide custom types as actions, or you can use the built in `StandardAction`.
+
+The `StandardAction` has the following structure:
+
+```swift
+struct StandardAction: Action {
+    // identifies the action
+    let type: String
+    // provides information that is relevant to processing this action
+    // e.g. details about which post should be favorited
+    let payload: [String : AnyObject]?
+    // this flag is used for serialization when working with ReSwift Recorder
+    let isTypedAction: Bool
+}
+```
+**For most applications it is recommended to create your own types for actions instead of using `StandardAction`, as this allows you to take advantage of Swift's type system**.
+
 To provide your own action, simply create a type that conforms to the `Action` protocol:
 
 ```swift
-struct SetOAuthURL: Action {
-    let oAuthUrl: URL
+struct LikePostAction: Action {
+    let post: Post
+    let userLikingPost: User
 }
 ```
+
+The advantage of using a `StandardAction` is that it can be serialized; this is required for using the features provided by [ReSwift Recorder](https://github.com/ReSwift/ReSwift-Recorder); such as persisting the application state between app launches.
+
+If you want to use custom types for actions, but still want to be able to make use of the features provided by ReSwift Recorder, you can implement the `StandardActionConvertible` protocol. This will allow ReSwift to convert your typed actions to standard actions that can then be serialized.
+
+Once ReSwift Recorder's implementation is further along, you will find detailed information  on all of this in its documentation.
 
 ## Reducers
 

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReSwift"
-  s.version          = "4.0.1"
+  s.version          = "4.1.0"
   s.summary          = "Unidirectional Data Flow in Swift"
   s.description      = <<-DESC
                         ReSwift is a Redux-like implementation of the unidirectional data flow architecture in Swift.

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -54,6 +54,9 @@
 		3F13C0EB1E7B3E4000D8442C /* SwiftLintIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F13C0EA1E7B3E4000D8442C /* SwiftLintIntegration.swift */; };
 		3F13C0ED1E7B3E4000D8442C /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
+		625AA6331C33AFB600FEB431 /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* StandardActionTests.swift */; };
+		625AA6341C33AFB700FEB431 /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* StandardActionTests.swift */; };
+		625AA6351C33AFB800FEB431 /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625AA6311C33AFA600FEB431 /* StandardActionTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
 		625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
@@ -142,6 +145,7 @@
 		3F13C0EC1E7B3E4000D8442C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
+		625AA6311C33AFA600FEB431 /* StandardActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardActionTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		625E66861C1FF97E0027C288 /* ReSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReSwift.h; sourceTree = "<group>"; };
 		625E66881C1FF97E0027C288 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -293,6 +297,7 @@
 			isa = PBXGroup;
 			children = (
 				625E669E1C1FFA3C0027C288 /* Info.plist */,
+				625AA6311C33AFA600FEB431 /* StandardActionTests.swift */,
 				D490BC41203F27E000902589 /* PerformanceTests.swift */,
 				73F39F331D3EE3C300DFFE62 /* StoreDispatchTests.swift */,
 				259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */,
@@ -772,6 +777,7 @@
 				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DC1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
 				73723E061D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
+				625AA6351C33AFB800FEB431 /* StandardActionTests.swift in Sources */,
 				73F39F3A1D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF741C30C34000D63A58 /* TypeHelperTests.swift in Sources */,
 				D490BC45203F291A00902589 /* PerformanceTests.swift in Sources */,
@@ -808,6 +814,7 @@
 				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DB1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
 				73723E051D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
+				625AA6341C33AFB700FEB431 /* StandardActionTests.swift in Sources */,
 				73F39F391D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF9F1C30C50000D63A58 /* TypeHelperTests.swift in Sources */,
 				D490BC44203F291900902589 /* PerformanceTests.swift in Sources */,
@@ -853,6 +860,7 @@
 				259737FB1C2C618A00869B8F /* TestFakes.swift in Sources */,
 				73E545DA1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
 				73723E041D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
+				625AA6331C33AFB600FEB431 /* StandardActionTests.swift in Sources */,
 				73F39F381D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,
 				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+
 /**
  This is ReSwift's built in action type, it is the only built in type that conforms to the
  `Action` protocol. `StandardAction` can be serialized and can therefore be used with developer
@@ -19,6 +20,7 @@ import Foundation
  to serialize your custom action types, you can implement `StandardActionConvertible` which will
  make it possible to generate a `StandardAction` from your typed action - the best of both worlds!
 */
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 public struct StandardAction: Action {
     /// A String that identifies the type of this `StandardAction`
     public let type: String
@@ -49,6 +51,7 @@ private let payloadKey = "payload"
 private let isTypedActionKey = "isTypedAction"
 let reSwiftNull = "ReSwift_Null"
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 extension StandardAction: Coding {
 
     public init?(dictionary: [String: AnyObject]) {
@@ -72,6 +75,7 @@ extension StandardAction: Coding {
 /// serializable.
 /// - Note: We are working on a tool to automatically generate the implementation of this protocol
 ///     for your custom action types.
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 public protocol StandardActionConvertible: Action {
     /**
      Within this initializer you need to use the payload from the `StandardAction` to configure the

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -6,10 +6,115 @@
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
+import Foundation
+/**
+ This is ReSwift's built in action type, it is the only built in type that conforms to the
+ `Action` protocol. `StandardAction` can be serialized and can therefore be used with developer
+ tools that restore state between app launches.
+
+ The downside of `StandardAction` is that it carries its payload as an untyped dictionary which does
+ not play well with Swift's type system.
+
+ It is recommended that you define your own types that conform to `Action` - if you want to be able
+ to serialize your custom action types, you can implement `StandardActionConvertible` which will
+ make it possible to generate a `StandardAction` from your typed action - the best of both worlds!
+*/
+public struct StandardAction: Action {
+    /// A String that identifies the type of this `StandardAction`
+    public let type: String
+    /// An untyped, JSON-compatible payload
+    public let payload: [String: AnyObject]?
+    /// Indicates whether this action will be deserialized as a typed action or as a standard action
+    public let isTypedAction: Bool
+
+    /**
+     Initializes this `StandardAction` with a type, a payload and information about whether this is
+     a typed action or not.
+
+     - parameter type:          String representation of the Action type
+     - parameter payload:       Payload convertable to JSON
+     - parameter isTypedAction: Is Action a subclassed type
+    */
+    public init(type: String, payload: [String: AnyObject]? = nil, isTypedAction: Bool = false) {
+        self.type = type
+        self.payload = payload
+        self.isTypedAction = isTypedAction
+    }
+}
+
+// MARK: Coding Extension
+
+private let typeKey = "type"
+private let payloadKey = "payload"
+private let isTypedActionKey = "isTypedAction"
+let reSwiftNull = "ReSwift_Null"
+
+extension StandardAction: Coding {
+
+    public init?(dictionary: [String: AnyObject]) {
+        guard let type = dictionary[typeKey] as? String,
+          let isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+        self.type = type
+        self.payload = dictionary[payloadKey] as? [String: AnyObject]
+        self.isTypedAction = isTypedAction
+    }
+
+    public var dictionaryRepresentation: [String: AnyObject] {
+        let payload: AnyObject = self.payload as AnyObject? ?? reSwiftNull as AnyObject
+
+        return [typeKey: type as NSString,
+                payloadKey: payload,
+                isTypedActionKey: isTypedAction as NSNumber]
+    }
+}
+
+/// Implement this protocol on your custom `Action` type if you want to make the action
+/// serializable.
+/// - Note: We are working on a tool to automatically generate the implementation of this protocol
+///     for your custom action types.
+public protocol StandardActionConvertible: Action {
+    /**
+     Within this initializer you need to use the payload from the `StandardAction` to configure the
+     state of your custom action type.
+
+     Example:
+
+     ```
+     init(_ standardAction: StandardAction) {
+        self.twitterUser = decode(standardAction.payload!["twitterUser"]!)
+     }
+     ```
+
+    - Note: If you, as most developers, only use action serialization/deserialization during
+     development, you can feel free to use the unsafe `!` operator.
+    */
+    init (_ standardAction: StandardAction)
+
+    /**
+     Use the information from your custom action to generate a `StandardAction`. The `type` of the
+     StandardAction should typically match the type name of your custom action type. You also need
+     to set `isTypedAction` to `true`. Use the information from your action's properties to
+     configure the payload of the `StandardAction`.
+
+     Example:
+
+     ```
+     func toStandardAction() -> StandardAction {
+        let payload = ["twitterUser": encode(self.twitterUser)]
+
+        return StandardAction(type: SearchTwitterScene.SetSelectedTwitterUser.type,
+            payload: payload, isTypedAction: true)
+     }
+     ```
+
+    */
+    func toStandardAction() -> StandardAction
+}
+
 /// All actions that want to be able to be dispatched to a store need to conform to this protocol
 /// Currently it is just a marker protocol with no requirements.
 public protocol Action { }
 
 /// Initial Action that is dispatched as soon as the store is created.
-/// Reducers respond to this action by configuring their initial state.
+/// Reducers respond to this action by configuring their intial state.
 public struct ReSwiftInit: Action {}

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -17,7 +17,11 @@ open class Store<State: StateType>: StoreType {
 
     typealias SubscriptionType = SubscriptionBox<State>
 
-    private(set) public var state: State! {
+    // swiftlint:disable todo
+    // TODO: Setter should not be public; need way for store enhancers to modify appState anyway
+    // swiftlint:enable todo
+
+    /*private (set)*/ public var state: State! {
         didSet {
             subscriptions.forEach {
                 if $0.subscriber == nil {

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -165,16 +165,19 @@ open class Store<State: StateType>: StoreType {
         dispatchFunction(action)
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ actionCreatorProvider: @escaping ActionCreator) {
         if let action = actionCreatorProvider(state, self) {
             dispatch(action)
         }
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ asyncActionCreatorProvider: @escaping AsyncActionCreator) {
         dispatch(asyncActionCreatorProvider, callback: nil)
     }
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     open func dispatch(_ actionCreatorProvider: @escaping AsyncActionCreator,
                        callback: DispatchCallback?) {
         actionCreatorProvider(state, self) { actionProvider in
@@ -189,8 +192,10 @@ open class Store<State: StateType>: StoreType {
 
     public typealias DispatchCallback = (State) -> Void
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     public typealias ActionCreator = (_ state: State, _ store: Store) -> Action?
 
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     public typealias AsyncActionCreator = (
         _ state: State,
         _ store: Store,

--- a/ReSwift/Info.plist
+++ b/ReSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.1</string>
+	<string>4.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReSwiftTests/StandardActionTests.swift
+++ b/ReSwiftTests/StandardActionTests.swift
@@ -1,0 +1,189 @@
+//
+//  StandardActionTests.swift
+//  ReSwift
+//
+//  Created by Benjamin Encz on 12/29/15.
+//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//
+
+import XCTest
+import ReSwift
+
+class StandardActionInitTests: XCTestCase {
+
+    /**
+     it can be initialized with just a type
+     */
+    func testInitWithType() {
+        let action = StandardAction(type: "Test")
+
+        XCTAssertEqual(action.type, "Test")
+    }
+
+    /**
+     it can be initialized with a type and a payload
+     */
+    func testInitWithTypeAndPayload() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject])
+
+        let payload = action.payload!["testKey"]! as! Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(action.type, "Test")
+    }
+
+}
+
+class StandardActionInitSerializationTests: XCTestCase {
+
+    /**
+     it can initialize action with a dictionary
+     */
+    func testCanInitWithDictionary() {
+        let actionDictionary: [String: AnyObject] = [
+            "type": "TestType" as AnyObject,
+            "payload": "ReSwift_Null" as AnyObject,
+            "isTypedAction": true as AnyObject
+        ]
+
+        let action = StandardAction(dictionary: actionDictionary)
+
+        XCTAssertEqual(action?.type, "TestType")
+        XCTAssertNil(action?.payload)
+        XCTAssertEqual(action?.isTypedAction, true)
+    }
+
+    /**
+     it can convert an action to a dictionary
+     */
+    func testConvertActionToDict() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject],
+            isTypedAction: true)
+
+        let dictionary = action.dictionaryRepresentation
+
+        let type = dictionary["type"] as! String
+        let payload = dictionary["payload"] as! [String: AnyObject]
+        let isTypedAction = dictionary["isTypedAction"] as! Bool
+
+        XCTAssertEqual(type, "Test")
+        XCTAssertEqual(payload["testKey"] as? Int, 5)
+        XCTAssertEqual(isTypedAction, true)
+    }
+
+    /**
+     it can serialize / deserialize actions with payload and without custom type
+     */
+    func testWithPayloadWithoutCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject])
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    /**
+     it can serialize / deserialize actions with payload and with custom type
+     */
+    func testWithPayloadAndCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject],
+                        isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertEqual(deserializedAction?.isTypedAction, true)
+    }
+
+    /**
+     it can serialize / deserialize actions without payload and without custom type
+     */
+    func testWithoutPayloadOrCustomType() {
+        let action = StandardAction(type:"Test", payload: nil)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    /**
+     it can serialize / deserialize actions without payload and with custom type
+     */
+    func testWithoutPayloadWithCustomType() {
+        let action = StandardAction(type:"Test", payload: nil,
+            isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertEqual(deserializedAction?.isTypedAction, true)
+    }
+
+    /**
+     it initializer returns nil when invalid dictionary is passed in
+     */
+    func testReturnsNilWhenInvalid() {
+        let deserializedAction = StandardAction(dictionary: [:])
+
+        XCTAssertNil(deserializedAction)
+    }
+}
+
+class StandardActionConvertibleInit: XCTestCase {
+
+    /**
+     it initializer returns nil when invalid dictionary is passed in
+     */
+    func testInitWithStandardAction() {
+        let standardAction = StandardAction(type: "Test", payload: ["value": 10 as AnyObject])
+        let action = SetValueAction(standardAction)
+
+        XCTAssertEqual(action.value, 10)
+    }
+
+    func testInitWithStringStandardAction() {
+        let standardAction = StandardAction(type: "Test", payload: ["value": "10" as AnyObject])
+        let action = SetValueStringAction(standardAction)
+
+        XCTAssertEqual(action.value, "10")
+    }
+
+}
+
+class StandardActionConvertibleTests: XCTestCase {
+
+    /**
+     it can be converted to a standard action
+     */
+    func testConvertToStandardAction() {
+        let action = SetValueAction(5)
+
+        let standardAction = action.toStandardAction()
+
+        XCTAssertEqual(standardAction.type, "SetValueAction")
+        XCTAssertEqual(standardAction.isTypedAction, true)
+        XCTAssertEqual(standardAction.payload?["value"] as? Int, 5)
+    }
+
+    func testConvertToStringStandardAction() {
+        let action = SetValueStringAction("5")
+
+        let standardAction = action.toStandardAction()
+
+        XCTAssertEqual(standardAction.type, "SetValueStringAction")
+        XCTAssertEqual(standardAction.isTypedAction, true)
+        XCTAssertEqual(standardAction.payload?["value"] as? String, "5")
+    }
+}

--- a/ReSwiftTests/StandardActionTests.swift
+++ b/ReSwiftTests/StandardActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import ReSwift
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 class StandardActionInitTests: XCTestCase {
 
     /**
@@ -34,6 +35,7 @@ class StandardActionInitTests: XCTestCase {
 
 }
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 class StandardActionInitSerializationTests: XCTestCase {
 
     /**
@@ -141,6 +143,7 @@ class StandardActionInitSerializationTests: XCTestCase {
     }
 }
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 class StandardActionConvertibleInit: XCTestCase {
 
     /**
@@ -162,6 +165,7 @@ class StandardActionConvertibleInit: XCTestCase {
 
 }
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
 class StandardActionConvertibleTests: XCTestCase {
 
     /**

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -37,6 +37,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it accepts action creators
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testAcceptsActionCreators() {
         store.dispatch(SetValueAction(5))
 
@@ -52,6 +53,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it accepts async action creators
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testAcceptsAsyncActionCreators() {
 
         let asyncExpectation = futureExpectation(
@@ -85,6 +87,7 @@ class StoreDispatchTests: XCTestCase {
     /**
      it calls the callback once state update from async action is complete
      */
+    @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
     func testCallsCalbackOnce() {
         let asyncExpectation = futureExpectation(withDescription:
             "It calls the callback once state update from async action is complete")

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import ReSwift
+import ReSwift
 
 class StoreDispatchTests: XCTestCase {
 

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import ReSwift
+import ReSwift
 
 let firstMiddleware: Middleware<StateType> = { dispatch, getState in
     return { next in

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -65,7 +65,7 @@ struct TestCustomAppState: StateType {
 
 struct NoOpAction: Action {}
 
-struct SetValueAction: StandardActionConvertible {
+struct SetValueAction {
 
     let value: Int?
     static let type = "SetValueAction"
@@ -73,19 +73,21 @@ struct SetValueAction: StandardActionConvertible {
     init (_ value: Int?) {
         self.value = value
     }
+}
 
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
+extension SetValueAction: StandardActionConvertible {
     init(_ standardAction: StandardAction) {
         self.value = standardAction.payload!["value"] as! Int?
     }
 
     func toStandardAction() -> StandardAction {
         return StandardAction(type: SetValueAction.type, payload: ["value": value as AnyObject],
-                                isTypedAction: true)
+                              isTypedAction: true)
     }
-
 }
 
-struct SetValueStringAction: StandardActionConvertible {
+struct SetValueStringAction {
 
     var value: String
     static let type = "SetValueStringAction"
@@ -94,6 +96,10 @@ struct SetValueStringAction: StandardActionConvertible {
         self.value = value
     }
 
+}
+
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
+extension SetValueStringAction: StandardActionConvertible {
     init(_ standardAction: StandardAction) {
         self.value = standardAction.payload!["value"] as! String
     }
@@ -106,7 +112,7 @@ struct SetValueStringAction: StandardActionConvertible {
 
 }
 
-struct SetCustomSubstateAction: StandardActionConvertible {
+struct SetCustomSubstateAction {
 
     var value: Int
     static let type = "SetCustomSubstateAction"
@@ -114,6 +120,11 @@ struct SetCustomSubstateAction: StandardActionConvertible {
     init (_ value: Int) {
         self.value = value
     }
+
+}
+
+@available(*, deprecated, message: "Moved to ReSwift-Recorder, unnecessary for base ReSwift usage.")
+extension SetCustomSubstateAction: StandardActionConvertible {
 
     init(_ standardAction: StandardAction) {
         self.value = standardAction.payload!["value"] as! Int

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -65,7 +65,7 @@ struct TestCustomAppState: StateType {
 
 struct NoOpAction: Action {}
 
-struct SetValueAction: Action {
+struct SetValueAction: StandardActionConvertible {
 
     let value: Int?
     static let type = "SetValueAction"
@@ -73,9 +73,19 @@ struct SetValueAction: Action {
     init (_ value: Int?) {
         self.value = value
     }
+
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! Int?
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueAction.type, payload: ["value": value as AnyObject],
+                                isTypedAction: true)
+    }
+
 }
 
-struct SetValueStringAction: Action {
+struct SetValueStringAction: StandardActionConvertible {
 
     var value: String
     static let type = "SetValueStringAction"
@@ -83,15 +93,36 @@ struct SetValueStringAction: Action {
     init (_ value: String) {
         self.value = value
     }
+
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! String
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueStringAction.type,
+                              payload: ["value": value as AnyObject],
+                              isTypedAction: true)
+    }
+
 }
 
-struct SetCustomSubstateAction: Action {
+struct SetCustomSubstateAction: StandardActionConvertible {
 
     var value: Int
     static let type = "SetCustomSubstateAction"
 
     init (_ value: Int) {
         self.value = value
+    }
+
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! Int
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueStringAction.type,
+                              payload: ["value": value as AnyObject],
+                              isTypedAction: true)
     }
 }
 

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -28,7 +28,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(StandardAction(type: ""), state: AppState1(), function: reducerFunction)
+        withSpecificTypes(NoOpAction(), state: AppState1(), function: reducerFunction)
 
         XCTAssertTrue(called)
     }
@@ -44,7 +44,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(StandardAction(type: ""), state: nil, function: reducerFunction)
+        withSpecificTypes(NoOpAction(), state: nil, function: reducerFunction)
 
         XCTAssertTrue(called)
     }
@@ -60,7 +60,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(StandardAction(type: ""), state: AppState2(), function: reducerFunction)
+        withSpecificTypes(NoOpAction(), state: AppState2(), function: reducerFunction)
 
         XCTAssertFalse(called)
     }

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -28,7 +28,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(NoOpAction(), state: AppState1(), function: reducerFunction)
+        withSpecificTypes(StandardAction(type: ""), state: AppState1(), function: reducerFunction)
 
         XCTAssertTrue(called)
     }
@@ -44,7 +44,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(NoOpAction(), state: nil, function: reducerFunction)
+        withSpecificTypes(StandardAction(type: ""), state: nil, function: reducerFunction)
 
         XCTAssertTrue(called)
     }
@@ -60,7 +60,7 @@ class TypeHelperTests: XCTestCase {
             return state ?? AppState1()
         }
 
-        withSpecificTypes(NoOpAction(), state: AppState2(), function: reducerFunction)
+        withSpecificTypes(StandardAction(type: ""), state: AppState2(), function: reducerFunction)
 
         XCTAssertFalse(called)
     }


### PR DESCRIPTION
This draft PR is to allow for someone to review a temporary branch I've created for releasing version 4.1 of ReSwift, and is not intended to be merged.

At this time the only thing holding up this release is a possible regression being discussed at https://github.com/ReSwift/ReSwift/issues/394 but I felt like we can get a head start on having approval of this branch for release while we work to resolve that issue.

Based on the conversations in https://github.com/ReSwift/ReSwift/issues/303 this release contains no breaking changes, and should act as an intermediate step before 5.0, which will include a number of breaking changes (removal of `StandardAction`, `AsyncAction`, and their counterparts)

As a summary, here is the Change log for 4.1:

**API Changes:**
- Deprecate `StandardAction` and `StandardActionConvertible` - @mjarvis
    
    - These have been moved to https://github.com/ReSwift/ReSwift-Recorder since they are unnecessary for the base use of ReSwift

- Deprecate `ActionCreator` and `AsyncActionCreator` (#391) - @mjarvis

    - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk

**Other**:
- Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
- Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
- Improve subscription & state update performance (#325) - @mjarvis
- Enable build settings "Allow app extension API only" (#328) - @oradyvan
- Open `Subscription<State>` to allow external extensions (#383) - @mjarvis