### PR TITLE
Resolve Xcode 10.2 warnings with Swift 4.2.2 and 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - osx_image: xcode10.2
       env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.2,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2
-      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=5.1,name=Apple Watch Series 4 - 44mm" SWIFT_VERSION="4.2" ACTION="build"
+      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=5.2,name=Apple Watch Series 4 - 44mm" SWIFT_VERSION="4.2" ACTION="build"
     - osx_image: xcode10.2
       env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.2,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
       env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1" ACTION="test"
     - osx_image: xcode10.1
       env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
-    - osx_image: xcode10.1
-      env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.0,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
-    - osx_image: xcode10.1
-      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
-    - osx_image: xcode10.1
-      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2
       env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.2
+      env: SCHEME="iOS"      SDK="iphonesimulator"    DESTINATION="OS=12.2,name=iPhone 8"          SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.2
+      env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=5.1,name=Apple Watch Series 4 - 44mm" SWIFT_VERSION="4.2" ACTION="build"
+    - osx_image: xcode10.2
+      env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.2,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2
       env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="5.0" ACTION="test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
     - osx_image: xcode10.1
       env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.2
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.2
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="5.0" ACTION="test"
 
 script:
   - set -o pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improve subscription & state update performance (#325) - @mjarvis
 - Enable build settings "Allow app extension API only" (#328) - @oradyvan
 - Open `Subscription<State>` to allow external extensions (#383) - @mjarvis
+- Resolve Xcode 10.2 warnings with Swift 4.2.2 and 5.0 (#397) - @mjarvis
 
 # 4.0.1
 

--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@
 # any of the actual ReSwift targets dirty or bloated a dummy target called
 # SwiftLintIntegration has been added.
 target 'SwiftLintIntegration' do
-  pod 'SwiftLint'
+  pod 'SwiftLint', '~> 0.27.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - SwiftLint
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - SwiftLint
+
 SPEC CHECKSUMS:
   SwiftLint: 1134786caedd2caab0560d2f36b76414a5a56808
 
 PODFILE CHECKSUM: 937d436496e317ef5f238fab841c0529d8f5d201
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - SwiftLint (0.22.0)
+  - SwiftLint (0.27.0)
 
 DEPENDENCIES:
-  - SwiftLint
+  - SwiftLint (~> 0.27.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  SwiftLint: 1134786caedd2caab0560d2f36b76414a5a56808
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
-PODFILE CHECKSUM: 937d436496e317ef5f238fab841c0529d8f5d201
+PODFILE CHECKSUM: 7bbdd45b8293c884aa09eb64369012f08940f4f7
 
 COCOAPODS: 1.6.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/travis/ReSwift/ReSwift/master.svg?style=flat-square)](https://travis-ci.org/ReSwift/ReSwift) [![Code coverage status](https://img.shields.io/codecov/c/github/ReSwift/ReSwift.svg?style=flat-square)](http://codecov.io/github/ReSwift/ReSwift) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ReSwift.svg?style=flat-square)](https://cocoapods.org/pods/ReSwift) [![Platform support](https://img.shields.io/badge/platform-ios%20%7C%20osx%20%7C%20tvos%20%7C%20watchos-lightgrey.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg?style=flat-square)](https://houndci.com)
 
-**Supported Swift Versions:** Swift 3.2, 4.0
+**Supported Swift Versions:** Swift 3.2, 4.0, 4.2, 5.0
 
 For Swift 2.2 Support use [Release 2.0.0](https://github.com/ReSwift/ReSwift/releases/tag/2.0.0) or earlier.
 

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -545,9 +545,11 @@
 					};
 					25DBCF7A1C30C4AA00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 1020;
 					};
 					25DBCF861C30C4DB00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 1020;
 					};
 					3F13C0E71E7B3E4000D8442C = {
 						CreatedOnToolsVersion = 8.2.1;

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 625E66791C1FF97E0027C288;
 			productRefGroup = 625E66841C1FF97E0027C288 /* Products */;

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -476,8 +476,6 @@
 				3F13C0E41E7B3E4000D8442C /* Sources */,
 				3F13C0E51E7B3E4000D8442C /* Frameworks */,
 				3F13C0E61E7B3E4000D8442C /* Resources */,
-				C6C5ED535A5FCEB5648419A2 /* [CP] Embed Pods Frameworks */,
-				3BED8D2D43A452D599C2F312 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -532,16 +530,20 @@
 		625E667A1C1FF97E0027C288 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Benjamin Encz";
 				TargetAttributes = {
 					25DBCF361C30BF2B00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 1020;
 					};
 					25DBCF4D1C30C18D00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 1020;
 					};
 					25DBCF631C30C1AC00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 1020;
 					};
 					25DBCF7A1C30C4AA00D63A58 = {
 						CreatedOnToolsVersion = 7.2;
@@ -553,19 +555,21 @@
 					};
 					3F13C0E71E7B3E4000D8442C = {
 						CreatedOnToolsVersion = 8.2.1;
+						LastSwiftMigration = 1020;
 					};
 					625E66821C1FF97E0027C288 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 1020;
 					};
 					625E66991C1FFA3C0027C288 = {
 						CreatedOnToolsVersion = 7.1.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 625E667D1C1FF97E0027C288 /* Build configuration list for PBXProject "ReSwift" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -648,21 +652,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BED8D2D43A452D599C2F312 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		6012A4D4990919B303E1357A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -708,21 +697,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/BuildPhases/run-swiftlint\"";
-		};
-		C6C5ED535A5FCEB5648419A2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -965,6 +939,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "reswift.github.io.ReSwift-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
 		};
@@ -977,6 +952,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
 		};
@@ -1075,6 +1051,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1142,6 +1119,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-iOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-macOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-tvOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-watchOS.xcscheme
+++ b/ReSwift.xcodeproj/xcshareddata/xcschemes/ReSwift-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -134,9 +134,15 @@ open class Store<State: StateType>: StoreType {
     }
 
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {
+        #if swift(>=5.0)
+        if let index = subscriptions.firstIndex(where: { return $0.subscriber === subscriber }) {
+            subscriptions.remove(at: index)
+        }
+        #else
         if let index = subscriptions.index(where: { return $0.subscriber === subscriber }) {
             subscriptions.remove(at: index)
         }
+        #endif
     }
 
     // swiftlint:disable:next identifier_name

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -20,14 +20,24 @@ class SubscriptionBox<State>: Hashable {
     weak var subscriber: AnyStoreSubscriber?
     private let objectIdentifier: ObjectIdentifier
 
-    #if compiler(>=5.0)
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(self.objectIdentifier)
-    }
+    #if swift(>=5.0)
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(self.objectIdentifier)
+        }
+    #elseif swift(>=4.2)
+        #if compiler(>=5.0)
+            func hash(into hasher: inout Hasher) {
+                hasher.combine(self.objectIdentifier)
+            }
+        #else
+            var hashValue: Int {
+                return self.objectIdentifier.hashValue
+            }
+        #endif
     #else
-    var hashValue: Int {
-        return self.objectIdentifier.hashValue
-    }
+        var hashValue: Int {
+            return self.objectIdentifier.hashValue
+        }
     #endif
 
     init<T>(

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -20,9 +20,15 @@ class SubscriptionBox<State>: Hashable {
     weak var subscriber: AnyStoreSubscriber?
     private let objectIdentifier: ObjectIdentifier
 
+    #if compiler(>=5.0)
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.objectIdentifier)
+    }
+    #else
     var hashValue: Int {
         return self.objectIdentifier.hashValue
     }
+    #endif
 
     init<T>(
         originalSubscription: Subscription<State>,

--- a/ReSwift/Utils/Assertions.swift
+++ b/ReSwift/Utils/Assertions.swift
@@ -16,7 +16,7 @@ import Foundation
  - parameter line:    Calling line
  */
 func raiseFatalError(_ message: @autoclosure () -> String = "",
-                              file: StaticString = #file, line: UInt = #line) -> Never {
+                     file: StaticString = #file, line: UInt = #line) -> Never {
     Assertions.fatalErrorClosure(message(), file, line)
     repeat {
         RunLoop.current.run()

--- a/ReSwiftTests/XCTest+Assertions.swift
+++ b/ReSwiftTests/XCTest+Assertions.swift
@@ -36,7 +36,7 @@ public extension XCTestCase {
         },
             expectedMessage: expectedMessage,
             testCase: testCase,
-            cleanUp:  {
+            cleanUp: {
                 Assertions.fatalErrorClosure = Assertions.swiftFatalErrorClosure
         })
     }
@@ -54,7 +54,7 @@ public extension XCTestCase {
         cleanUp: @escaping () -> Void) {
 
         let asyncExpectation = futureExpectation(withDescription: funcName + "-Expectation")
-        var assertionMessage: String? = nil
+        var assertionMessage: String?
 
         function { (message) -> Void in
             assertionMessage = message

--- a/ReSwiftTests/XCTest+Assertions.swift
+++ b/ReSwiftTests/XCTest+Assertions.swift
@@ -25,8 +25,8 @@ public extension XCTestCase {
      - parameter testCase:        The test case to be executed that expected to fire the assertion
      method.
      */
-    public func expectFatalError(expectedMessage: String? = nil, file: StaticString = #file,
-                                 line: UInt = #line, testCase: @escaping () -> Void) {
+    func expectFatalError(expectedMessage: String? = nil, file: StaticString = #file,
+                          line: UInt = #line, testCase: @escaping () -> Void) {
         expectAssertionNoReturnFunction(
             functionName: "fatalError",
             file: file,


### PR DESCRIPTION
Resolves #396

For compatibility reasons, `swift_version` has been left at 4.2. This works in both Xcode 10.1, as well as in Xcode 10.2 (which uses Swift 4.2.2), and is thus also cross-compatible with Swift 5.0.
I see no reason for us to update the project version to swift 5.0 as long as the compatibility mode exists, as Carthage users can mix 4.2.2 libraries with 5.0 code, and for CocoaPods it will use their specified swift version, not ours.