### PR TITLE
Update Changelog to include 4.1.0 & 4.1.1. release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,28 @@
     - Removes the ability to directly set `state` by making it `private(set)`. This prevents users from bypassing reducers and middleware. All mutation of the state must occur through the normal `Action` & `Reducer` methods.
     - This deprecates the usage of `ReSwift-Recorder`. Changes may be made to that library in the future in order to support this change.
 
+**Other**
+
+# 4.1.0
+
+*Released: 03/21/2019*
+
+**API Changes:**
+- Deprecate `StandardAction` and `StandardActionConvertible` - @mjarvis
+    
+    - These have been moved to https://github.com/ReSwift/ReSwift-Recorder since they are unnecessary for the base use of ReSwift
+
 - Deprecate `ActionCreator` and `AsyncActionCreator` (#391) - @mjarvis
 
     - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk
 
-**Other**:
+**Other**
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Improve subscription & state update performance (#325) - @mjarvis
 - Enable build settings "Allow app extension API only" (#328) - @oradyvan
 - Open `Subscription<State>` to allow external extensions (#383) - @mjarvis
-- Fix 4.1.0 regression with `automaticallySkipsRepeats` when selecting Equatable state in Non-Equatable root state (#399) - @djtech42
+- Update project to Swift 4.2 (#256, #335, #374) - @mjarvis, @DivineDominion
 
 # 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 **Other**
 
+# 4.1.1
+
+*Released: 03/21/2019*
+
+- Fix 4.1.0 regression with `automaticallySkipsRepeats` when selecting Equatable state in Non-Equatable root state (#399) - @djtech42
+
 # 4.1.0
 
 *Released: 03/21/2019*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     - Removes the ability to directly set `state` by making it `private(set)`. This prevents users from bypassing reducers and middleware. All mutation of the state must occur through the normal `Action` & `Reducer` methods.
     - This deprecates the usage of `ReSwift-Recorder`. Changes may be made to that library in the future in order to support this change.
 
-**Other**
+**Other:**
 
 # 4.1.1
 
@@ -32,7 +32,7 @@
 
     - These are deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk
 
-**Other**
+**Other:**
 - Add Subscription `skip(when:)` and `only(when:)` (#242) - @mjarvis
 - Add `automaticallySkipsRepeats` configuration option to Store initializer (#262) - @DivineDominion
 - Improve subscription & state update performance (#325) - @mjarvis
@@ -139,7 +139,7 @@
 **API Changes:**
 - Mark `Store` as `open`, this reverts a previously accidental breaking API Change (#157) - @Ben-G
 
-**Other**:
+**Other:**:
 - Update to Swift 3.0.1 - @Cristiam, @Ben-G
 - Documentation changes - @vkotovv
 
@@ -147,7 +147,7 @@
 
 *Released: 09/15/2016*
 
-**Other**:
+**Other:**
 
 - Swift 3 preview compatibility, maintaining Swift 2 naming - (#126) - @agentk
 - Xcode 8 GM Swift 3 Updates (#149) - @tkersey
@@ -159,11 +159,11 @@
 
 *Released: 06/27/2016*
 
-**Breaking API Changes**:
+**Breaking API Changes:**:
 
 - Significant Improvements to Serialization Code for `StandardAction` (relevant for recording tools) - @okla
 
-**Other**:
+**Other:**:
 
 - Swift 2.3 Updates - @agentk
 - Documentation Updates & Fixes - @okla, @gregpardo, @tomj, @askielboe, @mitsuse, @esttorhe, @RyanCCollins, @thomaspaulmann, @jlampa
@@ -213,7 +213,7 @@
 - Pass typed store reference into `ActionCreator`. `ActionCreator` can now access `Store`s state without the need for typecasts - @Ben-G
 - `Store` can now be initialized with an empty state, allowing reducers to hydrate the store - @Ben-G
 
-**Bugfixes**
+**Bugfixes:**
 
 - Break retain cycle when using middelware - @sendyhalim
 


### PR DESCRIPTION
4.1.0 and 4.1.1 were released off of a separate branch and thus these notes need to be backported to master.