### PR TITLE
fix automaticallySkipsRepeats when store has a state that is not equatable, but the selected substate is equatable (possible regression in 4.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improve subscription & state update performance (#325) - @mjarvis
 - Enable build settings "Allow app extension API only" (#328) - @oradyvan
 - Open `Subscription<State>` to allow external extensions (#383) - @mjarvis
+- Fix 4.1.0 regression with `automaticallySkipsRepeats` when selecting Equatable state in Non-Equatable root state (#399) - @djtech42
 
 # 4.0.1
 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -201,16 +201,7 @@ open class Store<State: StateType>: StoreType {
 
 // MARK: Skip Repeats for Equatable States
 
-extension Store where State: Equatable {
-    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
-        where S.StoreSubscriberStateType == State {
-            guard subscriptionsAutomaticallySkipRepeats else {
-                _ = subscribe(subscriber, transform: nil)
-                return
-            }
-            _ = subscribe(subscriber, transform: { $0.skipRepeats() })
-    }
-
+extension Store {
     open func subscribe<SelectedState: Equatable, S: StoreSubscriber>(
         _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?
         ) where S.StoreSubscriberStateType == SelectedState
@@ -223,5 +214,16 @@ extension Store where State: Equatable {
         }
         _subscribe(subscriber, originalSubscription: originalSubscription,
                    transformedSubscription: transformedSubscription)
+    }
+}
+
+extension Store where State: Equatable {
+    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
+        where S.StoreSubscriberStateType == State {
+            guard subscriptionsAutomaticallySkipRepeats else {
+                _ = subscribe(subscriber, transform: nil)
+                return
+            }
+            _ = subscribe(subscriber, transform: { $0.skipRepeats() })
     }
 }

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -179,21 +179,21 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
-    
+
     func testSkipsStateUpdatesForEquatableSubStateByDefault() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()
         let store = Store(reducer: reducer.handleAction, state: state)
         let subscriber = TestFilteredSubscriber<String>()
-        
+
         store.subscribe(subscriber) {
             $0.select { $0.testValue.testValue }
         }
-        
+
         XCTAssertEqual(subscriber.receivedValue, "Initial")
-        
+
         store.dispatch(SetValueStringAction("Initial"))
-        
+
         XCTAssertEqual(subscriber.receivedValue, "Initial")
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -179,6 +179,24 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
+    
+    func testSkipsStateUpdatesForEquatableSubStateByDefault() {
+        let reducer = TestNonEquatableReducer()
+        let state = TestNonEquatable()
+        let store = Store(reducer: reducer.handleAction, state: state)
+        let subscriber = TestFilteredSubscriber<String>()
+        
+        store.subscribe(subscriber) {
+            $0.select { $0.testValue.testValue }
+        }
+        
+        XCTAssertEqual(subscriber.receivedValue, "Initial")
+        
+        store.dispatch(SetValueStringAction("Initial"))
+        
+        XCTAssertEqual(subscriber.receivedValue, "Initial")
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
 
     func testPassesOnDuplicateStateUpdatesInCustomizedStore() {
         let reducer = TestValueStringReducer()

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -305,7 +305,7 @@ extension StoreSubscriptionTests {
 
         autoreleasepool {
 
-            store = TestStore(reducer: reducer.handleAction, state: TestAppState())
+            store = TestStore(reducer: reducer.handleAction, state: TestAppState(), automaticallySkipsRepeats: false)
             let subscriber = TestStoreSubscriber<Int?>()
 
             // Preconditions


### PR DESCRIPTION
It seems like it should look at if the substate from the transform is `Equatable` instead of both the state and substate for `subscribe`. 

When updating to 4.1.0, some substates stopped using `skipRepeats()` even though they were `Equatable` because the store's main state is not `Equatable`. The configuration `automaticallySkipsRepeats` can still be used to turn off automatic skipping for this case.