### PR TITLE
Update SwiftPM manifest file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,22 +28,28 @@ matrix:
       env: SCHEME="watchOS"  SDK="watchsimulator"     DESTINATION="OS=4.0,name=Apple Watch - 42mm" SWIFT_VERSION="4.2" ACTION="build"
     - osx_image: xcode10.1
       env: SCHEME="tvOS"     SDK="appletvsimulator"   DESTINATION="OS=12.0,name=Apple TV 4K"       SWIFT_VERSION="4.2" ACTION="test"
+    - osx_image: xcode10.2
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    TEST_SWIFTPM="true"
 
 script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
-  - xcodebuild
-    "$ACTION"
-    -project "$FRAMEWORK_NAME.xcodeproj"
-    -scheme "$FRAMEWORK_NAME-$SCHEME"
-    -sdk "$SDK"
-    -destination "$DESTINATION"
-    -configuration Debug
-    ONLY_ACTIVE_ARCH=YES
-    GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
-    GCC_GENERATE_TEST_COVERAGE_FILES=YES
-    SWIFT_VERSION=$SWIFT_VERSION
+  - if [ -z "$TEST_SWIFTPM" ]; then
+      xcodebuild
+      "$ACTION"
+      -project "$FRAMEWORK_NAME.xcodeproj"
+      -scheme "$FRAMEWORK_NAME-$SCHEME"
+      -sdk "$SDK"
+      -destination "$DESTINATION"
+      -configuration Debug
+      ONLY_ACTIVE_ARCH=YES
+      GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
+      GCC_GENERATE_TEST_COVERAGE_FILES=YES
+      SWIFT_VERSION=$SWIFT_VERSION
+    else
+      swift test
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J ReSwift

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ script:
       ONLY_ACTIVE_ARCH=YES
       GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
       GCC_GENERATE_TEST_COVERAGE_FILES=YES
-      SWIFT_VERSION=$SWIFT_VERSION
+      SWIFT_VERSION=$SWIFT_VERSION;
     else
-      swift test
+      swift test;
     fi
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - This deprecates the usage of `ReSwift-Recorder`. Changes may be made to that library in the future in order to support this change.
 
 **Other:**
+- Update Swift Package Manager support (#403) - @Dschee
 
 # 4.1.1
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,16 @@
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
     name: "ReSwift",
-    exclude: [
-      "ReSwiftTests",
-      "Carthage",
-      "Docs"
+    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "ReSwift", targets: ["ReSwift"])
+    ],
+    targets: [
+        .target(
+            name: "ReSwift",
+            path: "ReSwift"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,11 @@ let package = Package(
         .target(
             name: "ReSwift",
             path: "ReSwift"
+        ),
+        .testTarget(
+            name: "ReSwiftTests",
+            dependencies: ["ReSwift"],
+            path: "ReSwiftTests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ You can install ReSwift via [Carthage](https://github.com/Carthage/Carthage) by 
 github "ReSwift/ReSwift"
 ```
 
+### Accio
+
+You can install ReSwift via [Accio](https://github.com/JamitLabs/Accio) by adding the following line to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "4.1.1")),
+```
+
+Next, add `ReSwift` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "ReSwift",
+    ]
+),
+```
+
+Then run `accio update`.
+
 ## Swift Package Manager
 
 You can install ReSwift via [Swift Package Manager](https://swift.org/package-manager/) by adding the following line to your `Package.swift`:

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You can install ReSwift via [Carthage](https://github.com/Carthage/Carthage) by 
 github "ReSwift/ReSwift"
 ```
 
-### Accio
+## Accio
 
 You can install ReSwift via [Accio](https://github.com/JamitLabs/Accio) by adding the following line to your `Package.swift`:
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.