### PR TITLE
Update Swift Package Manager to v4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 let package = Package(
     name: "ReSwift",
-    exclude: [
-      "ReSwiftTests",
-      "Carthage",
-      "Docs"
+    products: [
+      .library(name: "ReSwift", targets: ["ReSwift"])
+    ],
+    targets: [
+      .target(name: "ReSwift", path: "ReSwift")
     ]
 )


### PR DESCRIPTION
Swift 5 no longer supports the Swift 3 Package.swift tools-version, which means Xcode 10.2 doesn't either. This updates Package.swift to the latest, version 4.2.