### PR TITLE
add swift package manager support for 5.0

### DIFF
--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.0
 import PackageDescription
 
-let pkg = Package(name "ReSwift")
+let pkg = Package(name: "ReSwift")
 pkg.platforms = [
     .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
 ]

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let pkg = Package(name "ReSwift")
+pkg.platforms = [
+    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+]
+pkg.products = [
+    .library(name: "ReSwift", targets: ["ReSwift"]),
+]
+
+let pmk: Target = .target(name: "ReSwift")
+pmk.path = "ReSwift"
+pkg.targets = [
+    pmk,
+    .testTarget(name: "ReSwiftTests", dependencies: ["ReSwift"], path: "ReSwiftTests"),
+]

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -6,12 +6,12 @@ pkg.platforms = [
     .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
 ]
 pkg.products = [
-    .library(name: "ReSwift", targets: ["ReSwift"]),
+    .library(name: "ReSwift", targets: ["ReSwift"])
 ]
 
 let pmk: Target = .target(name: "ReSwift")
 pmk.path = "ReSwift"
 pkg.targets = [
     pmk,
-    .testTarget(name: "ReSwiftTests", dependencies: ["ReSwift"], path: "ReSwiftTests"),
+    .testTarget(name: "ReSwiftTests", dependencies: ["ReSwift"], path: "ReSwiftTests")
 ]

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ import PackageDescription
 let package = Package(
     [...]
     dependencies: [
-        .Package(url: "https://github.com/ReSwift/ReSwift.git", majorVersion: XYZ)
+        .package(url: "https://github.com/ReSwift/ReSwift.git", from: "4.1.1"),
     ]
 )
 ```


### PR DESCRIPTION
I tried to use reswift from xcode11 with swift package manager .
I noticed that there is no swift package metafile for 5.0.