### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 **Other:**
 - Resolve Xcode 10.2 warnings with Swift 4.2.2 and 5.0 (#397) - @mjarvis
-- Update Swift Package Manager support (#403) - @Dschee
+- Update Swift Package Manager support (#403, #411) - @Dschee, @hoemoon
 
 # 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Upcoming
+# 5.0.0
+
+*Released: 2019-06-30* 
 
 **Breaking API Changes:**
 - Remove `StandardAction` and `StandardActionConvertible` (#270) - @mjarvis

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ github "ReSwift/ReSwift"
 You can install ReSwift via [Accio](https://github.com/JamitLabs/Accio) by adding the following line to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "4.1.1")),
+.package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "5.0.0")),
 ```
 
 Next, add `ReSwift` to your App targets dependencies like so:
@@ -218,7 +218,7 @@ import PackageDescription
 let package = Package(
     [...]
     dependencies: [
-        .package(url: "https://github.com/ReSwift/ReSwift.git", from: "4.1.1"),
+        .package(url: "https://github.com/ReSwift/ReSwift.git", from: "5.0.0"),
     ]
 )
 ```

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReSwift"
-  s.version          = "4.0.1"
+  s.version          = "5.0.0"
   s.summary          = "Unidirectional Data Flow in Swift"
   s.description      = <<-DESC
                         ReSwift is a Redux-like implementation of the unidirectional data flow architecture in Swift.

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -15,12 +15,18 @@ Pod::Spec.new do |s|
     "Christian Tietze" => "me@christiantietze.de"
   }
   s.documentation_url = "http://reswift.github.io/ReSwift/"
-  s.social_media_url = "http://twitter.com/benjaminencz"
-  s.source           = { :git => "https://github.com/ReSwift/ReSwift.git", :tag => s.version.to_s }
+  s.social_media_url  = "http://twitter.com/benjaminencz"
+  s.source            = {
+    :git => "https://github.com/ReSwift/ReSwift.git",
+    :tag => s.version.to_s
+  }
+
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.10'
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '2.0'
-  s.requires_arc = true
+
+  s.requires_arc     = true
   s.source_files     = 'ReSwift/**/*.swift'
+  s.swift_versions   = [ "5.0", "4.2", "3.2" ]
 end

--- a/ReSwift.podspec
+++ b/ReSwift.podspec
@@ -8,7 +8,12 @@ Pod::Spec.new do |s|
                         DESC
   s.homepage         = "https://github.com/ReSwift/ReSwift"
   s.license          = { :type => "MIT", :file => "LICENSE.md" }
-  s.author           = { "Benjamin Encz" => "me@benjamin-encz.de" }
+  s.author           = {
+    "Benjamin Encz" => "me@benjamin-encz.de",
+    "Karl Bowden" => "karl@karlbowden.com",
+    "Malcolm Jarvis" => "malcolm@boolable.ca",
+    "Christian Tietze" => "me@christiantietze.de"
+  }
   s.documentation_url = "http://reswift.github.io/ReSwift/"
   s.social_media_url = "http://twitter.com/benjaminencz"
   s.source           = { :git => "https://github.com/ReSwift/ReSwift.git", :tag => s.version.to_s }

--- a/ReSwift/Info.plist
+++ b/ReSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.1</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
The jazzy docs still show a badge with `4.0.1`. I have updated all references I could find to `5.0.0`, but I think something's wonky with regard to tags: 4.1.0 and 4.1.1 don't point to commits on `master`.

When we're done here, I'll tag the merge commit on master as `5.0.0` instead. That could help.

Closes #303 

--- 

When merged:

- [ ] Tag merge commit
- [ ] Add release notes from CHANGELOG to GitHub release
- [ ] Push to `pod trunk`