### PR TITLE
add key paths to subscription select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**Other:**
+- Add key paths to subscription select (#415) - @djtech42
+
 # 5.0.0
 
 *Released: 2019-06-30* 

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -114,6 +114,15 @@ public class Subscription<State> {
         return self._select(selector)
     }
 
+    /// Provides a subscription that selects a substate of the state of the original subscription.
+    /// - parameter keyPath: A key path from a state to a substate
+    public func select<Substate>(
+        _ keyPath: KeyPath<State, Substate>
+        ) -> Subscription<Substate>
+    {
+        return self._select { $0[keyPath: keyPath] }
+    }
+
     /// Provides a subscription that skips certain state updates of the original subscription.
     /// - parameter isRepeat: A closure that determines whether a given state update is a repeat and
     /// thus should be skipped and not forwarded to subscribers.

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -28,19 +28,19 @@ class AutomaticallySkipRepeatsTests: XCTestCase {
     }
 
     func testInitialSubscription() {
-        store.subscribe(self) { $0.select { $0.name } }
+        store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
     func testDispatchUnrelatedActionWithExplicitSkipRepeats() {
-        store.subscribe(self) { $0.select { $0.name }.skipRepeats() }
+        store.subscribe(self) { $0.select(\.name).skipRepeats() }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
     func testDispatchUnrelatedActionWithoutExplicitSkipRepeats() {
-        store.subscribe(self) { $0.select { $0.name } }
+        store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
         XCTAssertEqual(self.subscriptionUpdates, 1)

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -28,11 +28,23 @@ class AutomaticallySkipRepeatsTests: XCTestCase {
     }
 
     func testInitialSubscription() {
+        store.subscribe(self) { $0.select { $0.name } }
+        XCTAssertEqual(self.subscriptionUpdates, 1)
+    }
+
+    func testInitialSubscriptionKeyPath() {
         store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
     func testDispatchUnrelatedActionWithExplicitSkipRepeats() {
+        store.subscribe(self) { $0.select { $0.name }.skipRepeats() }
+        XCTAssertEqual(self.subscriptionUpdates, 1)
+        store.dispatch(ChangeAge(newAge: 30))
+        XCTAssertEqual(self.subscriptionUpdates, 1)
+    }
+
+    func testDispatchUnrelatedActionWithExplicitSkipRepeatsKeyPath() {
         store.subscribe(self) { $0.select(\.name).skipRepeats() }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
@@ -40,6 +52,13 @@ class AutomaticallySkipRepeatsTests: XCTestCase {
     }
 
     func testDispatchUnrelatedActionWithoutExplicitSkipRepeats() {
+        store.subscribe(self) { $0.select { $0.name } }
+        XCTAssertEqual(self.subscriptionUpdates, 1)
+        store.dispatch(ChangeAge(newAge: 30))
+        XCTAssertEqual(self.subscriptionUpdates, 1)
+    }
+
+    func testDispatchUnrelatedActionWithoutExplicitSkipRepeatsKeyPath() {
         store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -27,38 +27,38 @@ class AutomaticallySkipRepeatsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testInitialSubscription() {
+    func testInitialSubscriptionWithRegularSubstateSelection() {
         store.subscribe(self) { $0.select { $0.name } }
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
-    func testInitialSubscriptionKeyPath() {
+    func testInitialSubscriptionWithKeyPath() {
         store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
-    func testDispatchUnrelatedActionWithExplicitSkipRepeats() {
+    func testDispatchUnrelatedActionWithExplicitSkipRepeatsWithRegularSubstateSelection() {
         store.subscribe(self) { $0.select { $0.name }.skipRepeats() }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
-    func testDispatchUnrelatedActionWithExplicitSkipRepeatsKeyPath() {
+    func testDispatchUnrelatedActionWithExplicitSkipRepeatsWithKeyPath() {
         store.subscribe(self) { $0.select(\.name).skipRepeats() }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
-    func testDispatchUnrelatedActionWithoutExplicitSkipRepeats() {
+    func testDispatchUnrelatedActionWithoutExplicitSkipRepeatsWithRegularSubstateSelection() {
         store.subscribe(self) { $0.select { $0.name } }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))
         XCTAssertEqual(self.subscriptionUpdates, 1)
     }
 
-    func testDispatchUnrelatedActionWithoutExplicitSkipRepeatsKeyPath() {
+    func testDispatchUnrelatedActionWithoutExplicitSkipRepeatsWithKeyPath() {
         store.subscribe(self) { $0.select(\.name) }
         XCTAssertEqual(self.subscriptionUpdates, 1)
         store.dispatch(ChangeAge(newAge: 30))

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -82,7 +82,7 @@ class StoreSubscriberTests: XCTestCase {
     /**
      it does not notify subscriber for unchanged substate state when using `skipRepeats`.
      */
-    func testUnchangedStateSelector() {
+    func testUnchangedStateWithRegularSubstateSelection() {
         let reducer = TestReducer()
         var state = TestAppState()
         state.testValue = 3
@@ -103,7 +103,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testUnchangedStateKeyPath() {
+    func testUnchangedStateWithKeyPath() {
         let reducer = TestReducer()
         var state = TestAppState()
         state.testValue = 3
@@ -128,7 +128,7 @@ class StoreSubscriberTests: XCTestCase {
      it does not notify subscriber for unchanged substate state when using the default
      `skipRepeats` implementation.
      */
-    func testUnchangedStateSelectorDefaultSkipRepeats() {
+    func testUnchangedStateDefaultSkipRepeatsWithRegularSubstateSelection() {
         let reducer = TestValueStringReducer()
         let state = TestStringAppState()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -148,7 +148,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testUnchangedStateKeyPathDefaultSkipRepeats() {
+    func testUnchangedStateDefaultSkipRepeatsWithKeyPath() {
         let reducer = TestValueStringReducer()
         let state = TestStringAppState()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -171,7 +171,7 @@ class StoreSubscriberTests: XCTestCase {
     /**
      it skips repeated state values by when `skipRepeats` returns `true`.
      */
-    func testSkipsStateUpdatesForCustomEqualityChecks() {
+    func testSkipsStateUpdatesForCustomEqualityChecksWithRegularSubstateSelection() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -191,7 +191,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testSkipsStateUpdatesForCustomEqualityChecksKeyPath() {
+    func testSkipsStateUpdatesForCustomEqualityChecksWithKeyPath() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -211,7 +211,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testPassesOnDuplicateSubstateUpdatesByDefault() {
+    func testPassesOnDuplicateSubstateUpdatesByDefaultWithRegularSubstateSelection() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -229,7 +229,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 2)
     }
 
-    func testPassesOnDuplicateSubstateUpdatesByDefaultKeyPath() {
+    func testPassesOnDuplicateSubstateUpdatesByDefaultWithKeyPath() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -247,7 +247,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 2)
     }
 
-    func testPassesOnDuplicateSubstateWhenSkipsFalse() {
+    func testPassesOnDuplicateSubstateWhenSkipsFalseWithRegularSubstateSelection() {
         let reducer = TestValueStringReducer()
         let state = TestStringAppState()
         let store = Store(reducer: reducer.handleAction, state: state, middleware: [], automaticallySkipsRepeats: false)
@@ -265,7 +265,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 2)
     }
 
-    func testPassesOnDuplicateSubstateWhenSkipsFalseKeyPath() {
+    func testPassesOnDuplicateSubstateWhenSkipsFalseWithKeyPath() {
         let reducer = TestValueStringReducer()
         let state = TestStringAppState()
         let store = Store(reducer: reducer.handleAction, state: state, middleware: [], automaticallySkipsRepeats: false)
@@ -299,7 +299,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testSkipsStateUpdatesForEquatableSubStateByDefault() {
+    func testSkipsStateUpdatesForEquatableSubStateByDefaultWithRegularSubstateSelection() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -317,7 +317,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testSkipsStateUpdatesForEquatableSubStateByDefaultKeyPath() {
+    func testSkipsStateUpdatesForEquatableSubStateByDefaultWithKeyPath() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -351,7 +351,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 2)
     }
 
-    func testSkipWhen() {
+    func testSkipWhenWithRegularSubstateSelection() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -371,7 +371,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testSkipWhenKeyPath() {
+    func testSkipWhenWithKeyPath() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -391,7 +391,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testOnlyWhen() {
+    func testOnlyWhenWithRegularSubstateSelection() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)
@@ -411,7 +411,7 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
-    func testOnlyWhenKeyPath() {
+    func testOnlyWhenWithKeyPath() {
         let reducer = TestCustomAppStateReducer()
         let state = TestCustomAppState(substateValue: 5)
         let store = Store(reducer: reducer.handleAction, state: state)

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -37,6 +37,31 @@ class StoreSubscriberTests: XCTestCase {
     }
 
     /**
+     it allows to pass a state selector key path
+     */
+    func testAllowsSelectorKeyPath() {
+        let reducer = TestReducer()
+        let store = Store(reducer: reducer.handleAction, state: TestAppState())
+        let subscriber = TestFilteredSubscriber<Int?>()
+
+        store.subscribe(subscriber) {
+            $0.select(\.testValue)
+        }
+
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+
+        store.dispatch(SetValueAction(nil))
+
+        #if swift(>=4.1)
+            XCTAssertEqual(subscriber.receivedValue, .some(.none))
+        #else
+            XCTAssertEqual(subscriber.receivedValue, nil)
+        #endif
+    }
+
+    /**
      it supports complex state selector closures
      */
     func testComplexStateSelector() {
@@ -69,11 +94,9 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<Int?>()
 
         store.subscribe(subscriber) {
-            $0.select {
-                $0.testValue
-            }.skipRepeats {
-                return $0 == $1
-            }
+            $0
+            .select(\.testValue)
+            .skipRepeats { $0 == $1 }
         }
 
         XCTAssertEqual(subscriber.receivedValue, 3)
@@ -95,7 +118,9 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<String>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.testValue }.skipRepeats()
+            $0
+            .select(\.testValue)
+            .skipRepeats()
         }
 
         XCTAssertEqual(subscriber.receivedValue, "Initial")
@@ -116,8 +141,9 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.substate }
-                .skipRepeats { $0.value == $1.value }
+            $0
+            .select(\.substate)
+            .skipRepeats { $0.value == $1.value }
         }
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)
@@ -135,7 +161,7 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<NonEquatable>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.testValue }
+            $0.select(\.testValue)
         }
 
         XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
@@ -153,7 +179,7 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<String>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.testValue }
+            $0.select(\.testValue)
         }
 
         XCTAssertEqual(subscriber.receivedValue, "Initial")
@@ -187,7 +213,7 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<String>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.testValue.testValue }
+            $0.select(\.testValue.testValue)
         }
 
         XCTAssertEqual(subscriber.receivedValue, "Initial")
@@ -221,8 +247,9 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.substate }
-                .skip { $0.value == $1.value }
+            $0
+            .select(\.substate)
+            .skip { $0.value == $1.value }
         }
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)
@@ -240,8 +267,9 @@ class StoreSubscriberTests: XCTestCase {
         let subscriber = TestFilteredSubscriber<TestCustomAppState.TestCustomSubstate>()
 
         store.subscribe(subscriber) {
-            $0.select { $0.substate }
-                .only { $0.value != $1.value }
+            $0
+            .select(\.substate)
+            .only { $0.value != $1.value }
         }
 
         XCTAssertEqual(subscriber.receivedValue.value, 5)

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -302,7 +302,7 @@ extension StoreSubscriptionTests {
             autoreleasepool {
 
                 store.subscribe(subscriber, transform: {
-                    $0.select(\.testValue)
+                    $0.select { $0.testValue }
                 })
                 XCTAssertEqual(subscriber.receivedStates.count, 1)
                 let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -315,7 +315,7 @@ extension StoreSubscriptionTests {
             autoreleasepool {
 
                 store.subscribe(subscriber, transform: {
-                    $0.select({ $0.testValue })
+                    $0.select(\.testValue)
                 })
                 XCTAssertEqual(subscriber.receivedStates.count, 1)
                 let subscriptionBox = store.subscriptions.first! as! TestSubscriptionBox<TestAppState>


### PR DESCRIPTION
Example: `store.subscribe(self) { $0.select(\.name) }`