### PR TITLE
remove test variants for Swift 4.1 and lower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ env:
 
 matrix:
   include:
-    - osx_image: xcode9
-      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="3.2" ACTION="test"
-    - osx_image: xcode9.3
-      env: SCHEME="macOS"    SDK="macosx10.13"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.1" ACTION="test"
     - osx_image: xcode10.1
       env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="4.2" ACTION="test"
     - osx_image: xcode10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**Breaking API Changes:**
+- Drop support for Swift 3.2, 4.0, and 4.1. (#418) - @DivineDominion
+
 **Other:**
 - Make isDispatching of Store atomic (#341) - @zhongwuzw
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Build Status](https://img.shields.io/travis/ReSwift/ReSwift/master.svg?style=flat-square)](https://travis-ci.org/ReSwift/ReSwift) [![Code coverage status](https://img.shields.io/codecov/c/github/ReSwift/ReSwift.svg?style=flat-square)](http://codecov.io/github/ReSwift/ReSwift) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ReSwift.svg?style=flat-square)](https://cocoapods.org/pods/ReSwift) [![Platform support](https://img.shields.io/badge/platform-ios%20%7C%20osx%20%7C%20tvos%20%7C%20watchos-lightgrey.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/ReSwift/ReSwift/blob/master/LICENSE.md) [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg?style=flat-square)](https://houndci.com)
 
-**Supported Swift Versions:** Swift 3.2, 4.0, 4.2, 5.0
+**Supported Swift Versions:** Swift 4.2, 5.0
 
+For Swift 3.2 or 4.0 Support use [Release 5.0.0](https://github.com/ReSwift/ReSwift/releases/tag/5.0.0) or earlier.
 For Swift 2.2 Support use [Release 2.0.0](https://github.com/ReSwift/ReSwift/releases/tag/2.0.0) or earlier.
 
 # Introduction

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -568,7 +568,7 @@
 				};
 			};
 			buildConfigurationList = 625E667D1C1FF97E0027C288 /* Build configuration list for PBXProject "ReSwift" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -29,11 +29,7 @@ class StoreSubscriberTests: XCTestCase {
 
         store.dispatch(SetValueAction(nil))
 
-        #if swift(>=4.1)
-            XCTAssertEqual(subscriber.receivedValue, .some(.none))
-        #else
-            XCTAssertEqual(subscriber.receivedValue, nil)
-        #endif
+        XCTAssertEqual(subscriber.receivedValue, .some(.none))
     }
 
     /**

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -38,7 +38,7 @@ class StoreSubscriptionTests: XCTestCase {
         subscriber = nil
         XCTAssertEqual(store.subscriptions.compactMap({ $0.subscriber }).count, 0)
     }
-    
+
     /**
      it removes deferenced subscribers before notifying state changes
      */

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -28,7 +28,6 @@ class StoreSubscriptionTests: XCTestCase {
     /**
      It does not strongly capture an observer
      */
-    #if swift(>=4.1)
     func testDoesNotCaptureStrongly() {
         store = Store(reducer: reducer.handleAction, state: TestAppState())
         var subscriber: TestSubscriber? = TestSubscriber()
@@ -39,19 +38,7 @@ class StoreSubscriptionTests: XCTestCase {
         subscriber = nil
         XCTAssertEqual(store.subscriptions.compactMap({ $0.subscriber }).count, 0)
     }
-    #else
-    func testDoesNotCaptureStrongly() {
-        store = Store(reducer: reducer.handleAction, state: TestAppState())
-        var subscriber: TestSubscriber? = TestSubscriber()
-
-        store.subscribe(subscriber!)
-        XCTAssertEqual(store.subscriptions.flatMap({ $0.subscriber }).count, 1)
-
-        subscriber = nil
-        XCTAssertEqual(store.subscriptions.flatMap({ $0.subscriber }).count, 0)
-    }
-    #endif
-
+    
     /**
      it removes deferenced subscribers before notifying state changes
      */


### PR DESCRIPTION
I think we should be dropping support for Swift before 4.2 eventually. I removed conditional compiling instructions for Swift 4.1 and earlier. See #419 for the discussion

Closes #419. 