### PR TITLE
change organization name to "ReSwift Community"

### DIFF
--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = "Benjamin Encz";
+				ORGANIZATIONNAME = "ReSwift Community";
 				TargetAttributes = {
 					25DBCF361C30BF2B00D63A58 = {
 						CreatedOnToolsVersion = 7.2;

--- a/ReSwift/CoreTypes/Action.swift
+++ b/ReSwift/CoreTypes/Action.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 /// All actions that want to be able to be dispatched to a store need to conform to this protocol

--- a/ReSwift/CoreTypes/DispatchingStoreType.swift
+++ b/ReSwift/CoreTypes/DispatchingStoreType.swift
@@ -1,3 +1,5 @@
+//  Copyright © 2019 ReSwift Community. All rights reserved.
+
 import Foundation
 
 /**

--- a/ReSwift/CoreTypes/Middleware.swift
+++ b/ReSwift/CoreTypes/Middleware.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benji Encz on 12/24/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 public typealias DispatchFunction = (Action) -> Void

--- a/ReSwift/CoreTypes/Reducer.swift
+++ b/ReSwift/CoreTypes/Reducer.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 public typealias Reducer<ReducerStateType> =

--- a/ReSwift/CoreTypes/State.swift
+++ b/ReSwift/CoreTypes/State.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 public protocol StateType { }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/11/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 /**

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 public protocol AnyStoreSubscriber: class {

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/28/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 /**

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Virgilio Favero Neto on 4/02/2016.
-//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//  Copyright © 2016 ReSwift Community. All rights reserved.
 //
 
 /// A box around subscriptions and subscribers.

--- a/ReSwift/ReSwift.h
+++ b/ReSwift/ReSwift.h
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/ReSwift/Utils/Coding.swift
+++ b/ReSwift/Utils/Coding.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/27/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 public protocol Coding {

--- a/ReSwift/Utils/TypeHelper.swift
+++ b/ReSwift/Utils/TypeHelper.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/27/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 /**

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Daniel Martín Prieto on 03/11/2017.
-//  Copyright © 2017 Benjamin Encz. All rights reserved.
+//  Copyright © 2017 ReSwift Community. All rights reserved.
 //
 import XCTest
 import ReSwift

--- a/ReSwiftTests/PerformanceTests.swift
+++ b/ReSwiftTests/PerformanceTests.swift
@@ -1,3 +1,5 @@
+//  Copyright © 2019 ReSwift Community. All rights reserved.
+
 import XCTest
 import ReSwift
 

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Karl Bowden on 20/07/2016.
-//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//  Copyright © 2016 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -2,8 +2,8 @@
 //  StoreMiddlewareTests.swift
 //  ReSwift
 //
-//  Created by Benji Encz on 12/24/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Created by Benjamin Encz on 12/24/15.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -2,8 +2,8 @@
 //  StoreSubscriberTests.swift
 //  ReSwift
 //
-//  Created by Benji Encz on 1/23/16.
-//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//  Created by Benjamin Encz on 1/23/16.
+//  Copyright © 2016 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/27/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 11/27/15.
-//  Copyright © 2015 DigiTales. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -2,8 +2,8 @@
 //  TestFakes.swift
 //  ReSwift
 //
-//  Created by Benji Encz on 12/24/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Created by Benjamin Encz on 12/24/15.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 import Foundation

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -3,7 +3,7 @@
 //  ReSwift
 //
 //  Created by Benjamin Encz on 12/20/15.
-//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
 import XCTest

--- a/ReSwiftTests/XCTest+Compatibility.swift
+++ b/ReSwiftTests/XCTest+Compatibility.swift
@@ -1,3 +1,5 @@
+//  Copyright © 2019 ReSwift Community. All rights reserved.
+
 import XCTest
 
 func dispatchAsync(execute work: @escaping @convention(block) () -> Swift.Void) {


### PR DESCRIPTION
This affects project file creation templates.

I also went ahead and changed all copyright lines in the 2nd commit of this PR.

This changes files attributed to @Ben-G -- he's fine with the change.

Result:

```
//
//  Filename.swift
//  ReSwift
//
//  Created by Your Name Here on 2019-08-03.
//  Copyright © 2019 ReSwift Community. All rights reserved.
//
```