### PR TITLE
Run pod linter in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - osx_image: xcode10.2
       env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    SWIFT_VERSION="5.0" ACTION="test"
     - osx_image: xcode10.2
-      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    TEST_SWIFTPM="true"
+      env: SCHEME="macOS"    SDK="macosx10.14"        DESTINATION="arch=x86_64"                    TEST_SWIFTPM="true" POD_LINT="YES"
 
 script:
   - set -o pipefail
@@ -53,6 +53,9 @@ script:
       SWIFT_VERSION=$SWIFT_VERSION;
     else
       swift test;
+    fi
+  - if [ $POD_LINT == "YES" ]; then
+      pod lib lint --verbose;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ branches:
   except:
     - gh-pages
 
+before_install:
+  - gem install cocoapods -v '1.7.5'
+
 install:
   - gem install xcpretty
-  - gem update cocoapods
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
 
 install:
   - gem install xcpretty
+  - gem update cocoapods
 
 env:
   global:


### PR DESCRIPTION
I attached the new action to the configuration that tests SwiftPM, and skip it during all the others. We could just as well put it into the latest iPhone's configuration; I'm not sure if there's any difference.