### PR TITLE
Add capability to mutate middleware after store creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming
+
+**API Changes:**
+- Add capability to mutate `Middleware` after store creation. (#) - @mjarvis
+
 # 5.0.0
 
 *Released: 2019-06-30* 

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -76,7 +76,7 @@ open class Store<State: StateType>: StoreType {
         }
     }
 
-    private func createDispatchFunction() -> DispatchFunction {
+    private func createDispatchFunction() -> DispatchFunction! {
         // Wrap the dispatch function with all middlewares
         return middleware
             .reversed()


### PR DESCRIPTION
Resolves #426

In some cases, it can be useful to add or remove middleware after the Store is initialized, such as adding logging middleware while attempting to debug an issue, or removing middleware in order to playback raw actions without side-effects.

This exposes `public var middleware: [Middleware<State>]` to allow standard array mutation of the middleware at anytime in the Store's lifecycle.

We could also remove the implicit unwrapping on `var dispatchFunction: DispatchFunction!`, however I've chosen to leave it in in order to prevent any unexpected breaking changes if users were accessing or setting this variable, since it is `public`.

`didSet` is not called on variables if they are set during the init process of a class, and thus we need to manually create the dispatch function for the first access. This is solved by making `dispatchFunction` `lazy`, so that we do not need to assign it in the initializer.

This commit is a purely additive change, and should have zero effect on existing functionality.

TODO:
- [x] Add tests to ensure mutation of middleware is applied correctly.