### PR TITLE
Update Store's state setter to be internal, to allow state to be mutated directly from unit tests

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -17,7 +17,7 @@ open class Store<State: StateType>: StoreType {
 
     typealias SubscriptionType = SubscriptionBox<State>
 
-    private(set) public var state: State! {
+    internal(set) public var state: State! {
         didSet {
             subscriptions.forEach {
                 if $0.subscriber == nil {


### PR DESCRIPTION
There was a change awhile back to remove the public setter from the `Store`'s `state` property to encourage better state access patters. 

Before that change was made, we found that it was very helpful for us to be able to directly mutate a value in the store's state from our unit tests as a precursor to testing the effects of a particular reducer. 

Would you all be open to slightly reducing the restriction here so that the store's state setter was `internal` rather than `private`? This would allow us to `@testable import ReSwift` in our unit testes and modify the state directly, but still have the tighter restrictions on production code.