### PR TITLE
Resolve iOS deployment target version warning

### DIFF
--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let pkg = Package(name: "ReSwift")
 pkg.platforms = [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
 ]
 pkg.products = [
     .library(name: "ReSwift", targets: ["ReSwift"])


### PR DESCRIPTION
Using the ReSwift library, Xcode permanently shows the following warning at build time:

<img width="538" alt="ios-deployment-target-warning" src="https://user-images.githubusercontent.com/65533838/93662806-1b015580-fa63-11ea-8272-03b040a71b31.png">

To resolve this warning, I raised the minimum iOS platform version to `v9` since this is the official least minimum version available to set (according to the error message above).
