### PR TITLE
Update docs to denote enum-based actions.

### DIFF
--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -138,6 +138,15 @@ struct SetOAuthURL: Action {
 }
 ```
 
+Or you can combine related actions into an enum type:
+
+```swift
+enum AuthenticationAction: Action {
+    case setOAuthURL(oAuthUrl: URL)
+    case updateLoggedInState(loggedInState: Bool)
+}
+```
+
 ## Reducers
 
 Reducers are the **only place** in which you should **modify** application state. Reducers take the current application state and an action then return the new transformed application state. We recommend to provide many small reducers that each handle a subset of your application state.
@@ -157,7 +166,7 @@ func appReducer(action: Action, state: State?) -> State {
 }
 ```
 
-The `Reducer` typealias is a function that takes an `Action` and a `State?` then returns a `State`. Typically reducers will be responsible for initializing the application state. When they receive `nil` as the current state, they should return the initial default value for their portion of the state. In the example above the `appReducer` delegates all calls to other reducer functions. 
+The `Reducer` typealias is a function that takes an `Action` and a `State?` then returns a `State`. Typically reducers will be responsible for initializing the application state. When they receive `nil` as the current state, they should return the initial default value for their portion of the state. In the example above the `appReducer` delegates all calls to other reducer functions.
 
 For example, `authenticationReducer` is responsible for providing the `authenticationState`. Here's what the `authenticationReducer` function might look like:
 
@@ -171,6 +180,28 @@ func authenticationReducer(action: Action, state: AuthenticationState?) -> Authe
     case let action as SetOAuthURL:
         state.oAuthURL = action.oAuthUrl
     case let action as UpdateLoggedInState:
+        state.loggedInState = action.loggedInState
+    default:
+        break
+    }
+
+    return state
+}
+```
+
+Or it might look like this if you define your actions as an enum:
+
+```swift
+func authenticationReducer(action: Action, state: AuthenticationState?) -> AuthenticationState {
+    var state = state ?? initialAuthenticationState()
+
+    guard let action = action as? AuthenticationAction else {
+        return state
+    }
+
+    case let .setOAuthURL(oAuthUrl):
+        state.oAuthURL = oAuthUrl
+    case let .updateLoggedInState(loggedInState):
         state.loggedInState = action.loggedInState
     default:
         break

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -199,6 +199,7 @@ func authenticationReducer(action: Action, state: AuthenticationState?) -> Authe
         return state
     }
 
+    switch action {
     case let .setOAuthURL(oAuthUrl):
         state.oAuthURL = oAuthUrl
     case let .updateLoggedInState(loggedInState):

--- a/README.md
+++ b/README.md
@@ -61,9 +61,21 @@ struct CounterActionIncrease: Action {}
 struct CounterActionDecrease: Action {}
 ```
 
+Or you can define your actions as an enum if you prefer:
+
+```swift
+enum CounterAction: Action {
+
+    case .increase
+    case .decrease
+
+}
+```
+
 Your reducer needs to respond to these different action types, that can be done by switching over the type of action:
 
 ```swift
+// A reducer for actions represented in structs
 func counterReducer(action: Action, state: AppState?) -> AppState {
     var state = state ?? AppState()
 
@@ -78,7 +90,24 @@ func counterReducer(action: Action, state: AppState?) -> AppState {
 
     return state
 }
+
+// The same reducer for actions represented in enums
+func counterReducer(action: Action, state: AppState?) -> AppState {
+    var state = state ?? AppState()
+
+    switch action {
+    case CounterAction.counterActionIncrease:
+        state.counter += 1
+    case CounterAction.counterActionDecrease:
+        state.counter -= 1
+    default:
+        break
+    }
+
+    return state
+}
 ```
+
 In order to have a predictable app state, it is important that the reducer is always free of side effects, it receives the current app state and an action and returns the new app state.
 
 To maintain our state and delegate the actions to the reducers, we need a store. Let's call it `mainStore` and define it as a global constant, for example in the app delegate file:
@@ -95,10 +124,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 ```
 
-
 Lastly, your view layer, in this case a view controller, needs to tie into this system by subscribing to store updates and emitting actions whenever the app state needs to be changed:
 
 ```swift
+// for actions represented in structs
 class CounterViewController: UIViewController, StoreSubscriber {
 
     @IBOutlet var counterLabel: UILabel!
@@ -125,6 +154,21 @@ class CounterViewController: UIViewController, StoreSubscriber {
         mainStore.dispatch(
             CounterActionDecrease()
         )
+    }
+
+}
+
+// for actions represented in enums
+class CounterViewController: UIViewController, StoreSubscriber {
+
+    [...]
+
+    @IBAction func increaseButtonTapped(_ sender: UIButton) {
+        mainStore.dispatch(CounterAction.increase)
+    }
+
+    @IBAction func decreaseButtonTapped(_ sender: UIButton) {
+        mainStore.dispatch(CounterAction.decrease)
     }
 
 }


### PR DESCRIPTION
After adopting ReSwift in some of my projects, I found that combining related actions in enums can result cleaner code which is more readable and maintainable.

This pull request proposes to update related docs to denote this pattern.