### PR TITLE
Fix subscription test failure when built for release

### DIFF
--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -34,7 +34,6 @@ class StoreSubscriptionTests: XCTestCase {
 
         store.subscribe(subscriber!)
         XCTAssertEqual(store.subscriptions.compactMap({ $0.subscriber }).count, 1)
-        
         // Ensure `subscriber` is accessed at least once to prevent it being optimised
         // away when tests are built using 'release' scheme. #459 refers.
         XCTAssertNotNil(subscriber)

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -34,6 +34,10 @@ class StoreSubscriptionTests: XCTestCase {
 
         store.subscribe(subscriber!)
         XCTAssertEqual(store.subscriptions.compactMap({ $0.subscriber }).count, 1)
+        
+        // Ensure `subscriber` is accessed at least once to prevent it being optimised
+        // away when tests are built using 'release' scheme. #459 refers.
+        XCTAssertNotNil(subscriber)
 
         subscriber = nil
         XCTAssertEqual(store.subscriptions.compactMap({ $0.subscriber }).count, 0)


### PR DESCRIPTION
Resolves #459 

Original issue is a failing test in StoreSubscriptionTests when built for release.

This PR adds the discussed fix and supporting comment as it is not immediately apparent why a `XCTAssertNotNil` would normally be required at this point in the test.