### PR TITLE
Deprecate `StateType` protocol requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-<!--
 # Upcoming
 
 **Breaking API Changes:**
+
 **API Changes:**
+- Deprecate `StateType` protocol requirement (#462) - @mjarvis
+
 **Other:**
--->
+
 
 # 6.0.0
 

--- a/Docs/Getting Started Guide.md
+++ b/Docs/Getting Started Guide.md
@@ -14,12 +14,12 @@ This section will show you how to set up the core ReSwift components in your app
 
 ## High-Level Overview
 
-To get the infrastructure up and running you need to set up a `Store` for a root app state type. The type requirement is `ReSwift.Store<State: ReSwift.StateType>`. You set it up like this:
+To get the infrastructure up and running you need to set up a `Store` for a root app state type. The type requirement is `ReSwift.Store<State>`. You set it up like this:
 
 ```swift
 import ReSwift
 
-struct AppState: StateType {
+struct AppState {
     // ... app state properties here ...
 }
 
@@ -45,7 +45,7 @@ The process of implementing then works like this:
 For reference, the store's initializer and the initializer's type requirements all together look like this:
 
 ```swift
-class Store<State: StateType>: StoreType {
+class Store<State>: StoreType {
     public required init(
         reducer: @escaping Reducer<State>,
         state: State?,
@@ -70,7 +70,7 @@ If you want to see how you can fill in the gaps we left above, take a look at th
 ```swift
 import ReSwift
 
-struct AppState: StateType {
+struct AppState {
     var count = 0
 }
 
@@ -111,16 +111,13 @@ The application state is defined in a single data structure, which should be a `
 Here's an example of a state struct as defined in the [Counter Example](https://github.com/ReSwift/CounterExample-Navigation-TimeTravel):
 
 ```swift
-struct AppState: StateType {
+struct AppState {
     var counter: Int = 0
     var navigationState = NavigationState()
 }
 ```
 
-There are multiple things to note:
-
-1. Your app state struct needs to conform to the `StateType` protocol, currently this is just a marker protocol.
-2. If you are including `ReSwiftRouter` in your project, your app state needs to contain a property of type `NavigationState`. This is the sub-state the router will use to store the current route.
+If you are including `ReSwiftRouter` in your project, your app state needs to contain a property of type `NavigationState`. This is the sub-state the router will use to store the current route.
 
 ### Derived State
 

--- a/Docs/State.md
+++ b/Docs/State.md
@@ -5,13 +5,10 @@ The state `struct` should store your entire application state, that includes the
 Here's an example of a state `struct` as defined in the [Counter Example](https://github.com/ReSwift/CounterExample):
 
 ```swift
-struct AppState: StateType, HasNavigationState {
+struct AppState: HasNavigationState {
     var counter: Int = 0
     var navigationState = NavigationState()
 }
 ```
 
-There are multiple things to note:
-
-1. Your app state `struct` needs to conform to the `StateType` protocol, currently this is just a marker protocol, but we will likely add requirements (such as the ability to [serialize the state](https://github.com/ReSwift/ReSwift/issues/3)) before v1.0.
-2. If you are including `SwiftRouter` in your project, your app state needs to conform to the `HasNavigationState` protocol. This means you need to add a property called `navigationState` to your state `struct`. This is the sub-state the router will use to store the current route.
+If you are including `SwiftRouter` in your project, your app state needs to conform to the `HasNavigationState` protocol. This means you need to add a property called `navigationState` to your state `struct`. This is the sub-state the router will use to store the current route.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ReSwift relies on a few principles:
 For a very simple app, that maintains a counter that can be increased and decreased, you can define the app state as following:
 
 ```swift
-struct AppState: StateType {
+struct AppState {
     var counter: Int = 0
 }
 ```

--- a/ReSwift/CoreTypes/State.swift
+++ b/ReSwift/CoreTypes/State.swift
@@ -6,4 +6,7 @@
 //  Copyright © 2015 ReSwift Community. All rights reserved.
 //
 
+@available(*, deprecated, message: """
+Conforming your state to `StateType` is no longer necessary. You may remove this conformance.
+""")
 public protocol StateType { }

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -13,7 +13,7 @@
  reducers you can combine them by initializng a `MainReducer` with all of your reducers as an
  argument.
  */
-open class Store<State: StateType>: StoreType {
+open class Store<State>: StoreType {
 
     typealias SubscriptionType = SubscriptionBox<State>
 
@@ -87,7 +87,7 @@ open class Store<State: StateType>: StoreType {
                     // If the store get's deinitialized before the middleware is complete; drop
                     // the action without dispatching.
                     let dispatch: (Action) -> Void = { [weak self] in self?.dispatch($0) }
-                    let getState = { [weak self] in self?.state }
+                    let getState: () -> State? = { [weak self] in self?.state }
                     return middleware(dispatch, getState)(dispatchFunction)
             })
     }

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -14,7 +14,7 @@
  */
 public protocol StoreType: DispatchingStoreType {
 
-    associatedtype State: StateType
+    associatedtype State
 
     /// The current state stored in the store.
     var state: State! { get }

--- a/ReSwift/Utils/TypeHelper.swift
+++ b/ReSwift/Utils/TypeHelper.swift
@@ -19,16 +19,16 @@
 @discardableResult
 func withSpecificTypes<SpecificStateType, Action>(
         _ action: Action,
-        state genericStateType: StateType?,
+        state genericStateType: Any?,
         function: (_ action: Action, _ state: SpecificStateType?) -> SpecificStateType
-    ) -> StateType {
+    ) -> Any {
         guard let genericStateType = genericStateType else {
-            return function(action, nil) as! StateType
+            return function(action, nil) as Any
         }
 
         guard let specificStateType = genericStateType as? SpecificStateType else {
             return genericStateType
         }
 
-        return function(action, specificStateType) as! StateType
+        return function(action, specificStateType) as Any
 }

--- a/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
+++ b/ReSwiftTests/AutomaticallySkipRepeatsTests.swift
@@ -73,7 +73,7 @@ extension AutomaticallySkipRepeatsTests: StoreSubscriber {
     }
 }
 
-private struct State: StateType {
+private struct State {
     let age: Int
     let name: String
 }

--- a/ReSwiftTests/PerformanceTests.swift
+++ b/ReSwiftTests/PerformanceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import ReSwift
 
 final class PerformanceTests: XCTestCase {
-    struct MockState: StateType {}
+    struct MockState {}
     struct MockAction: Action {}
 
     let subscribers: [MockSubscriber] = (0..<3000).map { _ in MockSubscriber() }

--- a/ReSwiftTests/StoreMiddlewareTests.swift
+++ b/ReSwiftTests/StoreMiddlewareTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import ReSwift
 
-let firstMiddleware: Middleware<StateType> = { dispatch, getState in
+let firstMiddleware: Middleware<Any> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -23,7 +23,7 @@ let firstMiddleware: Middleware<StateType> = { dispatch, getState in
     }
 }
 
-let secondMiddleware: Middleware<StateType> = { dispatch, getState in
+let secondMiddleware: Middleware<Any> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -37,7 +37,7 @@ let secondMiddleware: Middleware<StateType> = { dispatch, getState in
     }
 }
 
-let dispatchingMiddleware: Middleware<StateType> = { dispatch, getState in
+let dispatchingMiddleware: Middleware<Any> = { dispatch, getState in
     return { next in
         return { action in
 
@@ -71,7 +71,7 @@ let stateAccessingMiddleware: Middleware<TestStringAppState> = { dispatch, getSt
     }
 }
 
-func middleware(executing block: @escaping () -> Void) -> Middleware<StateType> {
+func middleware(executing block: @escaping () -> Void) -> Middleware<Any> {
     return { dispatch, getState in
         return { next in
             return { action in

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -455,7 +455,7 @@ class TestSelectiveSubscriber: StoreSubscriber {
     }
 }
 
-struct TestComplexAppState: StateType {
+struct TestComplexAppState {
     var testValue: Int?
     var otherState: OtherState?
 }

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -239,7 +239,7 @@ private class TestSubscriptionBox<S>: SubscriptionBox<S> {
     }
 }
 
-private class TestStore<State: StateType>: Store<State> {
+private class TestStore<State>: Store<State> {
     override func subscriptionBox<T>(
         originalSubscription: Subscription<State>,
         transformedSubscription: Subscription<T>?,

--- a/ReSwiftTests/StoreTests.swift
+++ b/ReSwiftTests/StoreTests.swift
@@ -41,7 +41,7 @@ class StoreTests: XCTestCase {
 }
 
 // Used for deinitialization test
-class DeInitStore<State: StateType>: Store<State> {
+class DeInitStore<State>: Store<State> {
     var deInitAction: (() -> Void)?
 
     deinit {
@@ -73,7 +73,7 @@ class DeInitStore<State: StateType>: Store<State> {
     }
 }
 
-struct CounterState: StateType {
+struct CounterState {
     var count: Int = 0
 }
 

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ReSwift
 
-struct TestAppState: StateType {
+struct TestAppState {
     var testValue: Int?
 
     init() {
@@ -17,7 +17,7 @@ struct TestAppState: StateType {
     }
 }
 
-struct TestStringAppState: StateType {
+struct TestStringAppState {
     var testValue: String
 
     init() {
@@ -31,7 +31,7 @@ extension TestStringAppState: Equatable {
     }
 }
 
-struct TestNonEquatable: StateType {
+struct TestNonEquatable {
     var testValue: NonEquatable
 
     init() {
@@ -47,7 +47,7 @@ struct NonEquatable {
     }
 }
 
-struct TestCustomAppState: StateType {
+struct TestCustomAppState {
     var substate: TestCustomSubstate
 
     init(substate: TestCustomSubstate) {

--- a/ReSwiftTests/TypeHelperTests.swift
+++ b/ReSwiftTests/TypeHelperTests.swift
@@ -12,8 +12,8 @@ import XCTest
  */
 @testable import ReSwift
 
-struct AppState1: StateType {}
-struct AppState2: StateType {}
+struct AppState1 {}
+struct AppState2 {}
 
 class TypeHelperTests: XCTestCase {
 


### PR DESCRIPTION
Improvements in Swift Generics over the years have allowed us to remove this protocol requirement.

As far as I can tell we have no general need for this type, and can usually use `Any` or a generic in place of this when necessary (state types for middleware, etc).

The type has been left in, but deprecated, so this should not be a breaking change.