### PR TITLE
Fix bug where automaticallySkipsRepeats is ignored on generic StoreType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-<!--
 # Upcoming
 
 **Breaking API Changes:**
 **API Changes:**
+
 **Other:**
--->
+- Fix bug where automaticallySkipsRepeats is ignored when subscribing on generic `S: StateType` (#463) - @mjarvis
 
 # 6.0.0
 

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -52,6 +52,25 @@ public protocol StoreType: DispatchingStoreType {
     ) where S.StoreSubscriberStateType == SelectedState
 
     /**
+     Subscribes the provided subscriber to this store.
+     Subscribers will receive a call to `newState` whenever the
+     state in this store changes and the subscription decides to forward
+     state update.
+
+     This variation is used when substate conforms to `Equatable` and
+     `automaticallySkipsRepeats` is enabled on the store.
+
+     - parameter subscriber: Subscriber that will receive store updates
+     - parameter transform: A closure that receives a simple subscription and can return a
+       transformed subscription. Subscriptions can be transformed to only select a subset of the
+       state, or to skip certain state updates.
+     - note: Subscriptions are not ordered, so an order of state updates cannot be guaranteed.
+     */
+    func subscribe<SelectedState: Equatable, S: StoreSubscriber>(
+        _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?
+    ) where S.StoreSubscriberStateType == SelectedState
+
+    /**
      Unsubscribes the provided subscriber. The subscriber will no longer
      receive state updates from this store.
 

--- a/ReSwiftTests/StoreSubscriberTests.swift
+++ b/ReSwiftTests/StoreSubscriberTests.swift
@@ -317,6 +317,29 @@ class StoreSubscriberTests: XCTestCase {
         XCTAssertEqual(subscriber.newStateCallCount, 1)
     }
 
+    func testSkipsStateUpdatesForEquatableSubStateByDefaultWithKeyPathOnGenericStoreType() {
+        let reducer = TestNonEquatableReducer()
+        let state = TestNonEquatable()
+        let store = Store(reducer: reducer.handleAction, state: state)
+
+        func runTests<S: StoreType>(store: S) where S.State == TestNonEquatable {
+            let subscriber = TestFilteredSubscriber<String>()
+
+            store.subscribe(subscriber) {
+                $0.select(\.testValue.testValue)
+            }
+
+            XCTAssertEqual(subscriber.receivedValue, "Initial")
+
+            store.dispatch(SetValueStringAction("Initial"))
+
+            XCTAssertEqual(subscriber.receivedValue, "Initial")
+            XCTAssertEqual(subscriber.newStateCallCount, 1)
+        }
+
+        runTests(store: store)
+    }
+
     func testSkipsStateUpdatesForEquatableSubStateByDefaultWithKeyPath() {
         let reducer = TestNonEquatableReducer()
         let state = TestNonEquatable()


### PR DESCRIPTION
If a user was to make a subscription to equatable state using a generic `S: StoreType`, swift would use the default implementation in the store rather than the `SubState: Equatable` extension.

By adding this variation to the `StoreType` protocol, we can ensure that the correct function is called.

A unit test has been added that fails before the protocol addition, and passes after.