### PR TITLE
Fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@
 
 - `dispatch` functions now return `Void` instead of `Any` (#187) - @Qata
 
-  - The return type has been removed without any replacement, since the core team did not find any use cases of it. A common usage of the return type in redux is returning a promise that is fullfilled when a dispatched action is processed. While it's generally discouraged to disrupt the unidirectional data flow using this mechanism we do provide a `dispatch` overload that takes a `callback` argument and serves this purpose.
+  - The return type has been removed without any replacement, since the core team did not find any use cases of it. A common usage of the return type in redux is returning a promise that is fulfilled when a dispatched action is processed. While it's generally discouraged to disrupt the unidirectional data flow using this mechanism we do provide a `dispatch` overload that takes a `callback` argument and serves this purpose.
 
 - Make `dispatch` argument in middleware non-optional (#225) -  @dimazen, @mjarvis, @Ben-G
 
@@ -233,7 +233,7 @@
 **Fixes:**
 
 - Fix retain cycle caused by middleware (issue: #66) - @Ben-G
-- Store now holds weak references to subscribers to avoid unexpected memory managegement behavior (issue: #62) - @vfn
+- Store now holds weak references to subscribers to avoid unexpected memory management behavior (issue: #62) - @vfn
 - Documentation Fixes - @victorpimentel, @vfn, @juggernate, @raheelahmad
 
 **Other:**

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -10,7 +10,7 @@
  This class is the default implementation of the `StoreType` protocol. You will use this store in most
  of your applications. You shouldn't need to implement your own store.
  You initialize the store with a reducer and an initial application state. If your app has multiple
- reducers you can combine them by initializng a `MainReducer` with all of your reducers as an
+ reducers you can combine them by initializing a `MainReducer` with all of your reducers as an
  argument.
  */
 open class Store<State>: StoreType {

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -105,7 +105,7 @@ public protocol StoreType: DispatchingStoreType {
      This action creator can then be dispatched as following:
 
      ```
-     store.dispatch( noteActionCreatore.deleteNote(3) )
+     store.dispatch( noteActionCreator.deleteNote(3) )
      ```
      */
     func dispatch(_ actionCreator: ActionCreator)
@@ -122,7 +122,7 @@ public protocol StoreType: DispatchingStoreType {
      triggered by the asynchronously generated action creator.
 
      This overloaded version of `dispatch` calls the provided `callback` as soon as the
-     asynchronoously dispatched action has caused a new state calculation.
+     asynchronously dispatched action has caused a new state calculation.
 
      - Note: If the ActionCreator does not dispatch an action, the callback block will never
      be called
@@ -134,7 +134,7 @@ public protocol StoreType: DispatchingStoreType {
      This callback will be called when the dispatched action triggers a new state calculation.
      This is useful when you need to wait on a state change, triggered by an action (e.g. wait on
      a successful login). However, you should try to use this callback very seldom as it
-     deviates slighlty from the unidirectional data flow principal.
+     deviates slightly from the unidirectional data flow principal.
      */
     associatedtype DispatchCallback = (State) -> Void
 

--- a/ReSwiftTests/StoreDispatchTests.swift
+++ b/ReSwiftTests/StoreDispatchTests.swift
@@ -88,7 +88,7 @@ class StoreDispatchTests: XCTestCase {
      it calls the callback once state update from async action is complete
      */
     @available(*, deprecated, message: "Deprecated in favor of https://github.com/ReSwift/ReSwift-Thunk")
-    func testCallsCalbackOnce() {
+    func testCallsCallbackOnce() {
         let asyncExpectation = futureExpectation(withDescription:
             "It calls the callback once state update from async action is complete")
 

--- a/ReSwiftTests/XCTest+Assertions.swift
+++ b/ReSwiftTests/XCTest+Assertions.swift
@@ -61,7 +61,7 @@ public extension XCTestCase {
             asyncExpectation.fulfill()
         }
 
-        // act, perform on separate thead because a call to function runs forever
+        // act, perform on separate thread because a call to function runs forever
         dispatchUserInitiatedAsync(execute: testCase)
 
         waitForFutureExpectations(withTimeout: noReturnFailureWaitTime) { _ in


### PR DESCRIPTION
The intention of this PR is to fix some typos in order to improve reading experience and quality as well :)

Notice: correction on deprecated function `testCallsCallbackOnce()` may break some calling convention.