### PR TITLE
Updates StoreType.swift to have @available annotation

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -15,6 +15,8 @@ import Combine
  reducers you can combine them by initializng a `MainReducer` with all of your reducers as an
  argument.
  */
+@available(watchOS 6.0, *)
+@available(iOS 13.0, *)
 open class Store<State: StateType>: StoreType, ObservableObject {
 
     @Published private(set) public var state: State

--- a/ReSwift/CoreTypes/StoreType.swift
+++ b/ReSwift/CoreTypes/StoreType.swift
@@ -14,6 +14,9 @@ import Combine
  Stores receive actions and use reducers combined with these actions, to calculate state changes.
  Upon every state update a store informs all of its subscribers.
  */
+@available(iOS 13.0, *)
+@available(watchOS 6.0, *)
+@available(macOS 10.15, *)
 public protocol StoreType: DispatchingStoreType, ObservableObject {
 
     associatedtype State: StateType


### PR DESCRIPTION
XCode will not allow my WatchOS project to build without this. 