### PR TITLE
Fix test for intial state dispatch upon subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **API Changes:**
 
 **Other:**
+- Add tests to clarify initial state dispatch (#485) - @DivineDominion
 
 # 6.1.0
 

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -104,6 +104,19 @@ class StoreSubscriptionTests: XCTestCase {
     }
 
     /**
+     it dispatches initial value upon subscription and subsequent state changes
+     */
+    func testDispatchStateChanges() {
+        store = Store(reducer: reducer.handleAction, state: TestAppState())
+        let subscriber = TestSubscriber()
+
+        store.subscribe(subscriber)
+        store.dispatch(SetValueAction(9))
+
+        XCTAssertEqual(subscriber.receivedStates.map(\.testValue), [nil, 9])
+    }
+
+    /**
      it allows dispatching from within an observer
      */
     func testAllowDispatchWithinObserver() {

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -117,6 +117,21 @@ class StoreSubscriptionTests: XCTestCase {
     }
 
     /**
+     it dispatches initial value upon subscription and subsequent state changes
+     */
+    func testDispatchInitialStateAfterStateChange() {
+        store = Store(reducer: reducer.handleAction, state: TestAppState())
+        let subscriber = TestSubscriber()
+
+        // Change state first ...
+        store.dispatch(SetValueAction(13))
+        // ... and then subscribe to receive the current state.
+        store.subscribe(subscriber)
+
+        XCTAssertEqual(subscriber.receivedStates.map(\.testValue), [13])
+    }
+
+    /**
      it allows dispatching from within an observer
      */
     func testAllowDispatchWithinObserver() {

--- a/ReSwiftTests/StoreSubscriptionTests.swift
+++ b/ReSwiftTests/StoreSubscriptionTests.swift
@@ -90,17 +90,17 @@ class StoreSubscriptionTests: XCTestCase {
         // Only a single further state update, since latest subscription skips repeated values.
         XCTAssertEqual(subscriber.receivedStates.count, 3)
     }
+
     /**
      it dispatches initial value upon subscription
      */
     func testDispatchInitialValue() {
-        store = Store(reducer: reducer.handleAction, state: TestAppState())
+        store = Store(reducer: reducer.handleAction, state: TestAppState(testValue: 7))
         let subscriber = TestSubscriber()
 
         store.subscribe(subscriber)
-        store.dispatch(SetValueAction(3))
 
-        XCTAssertEqual(subscriber.receivedStates.last?.testValue, 3)
+        XCTAssertEqual(subscriber.receivedStates.map(\.testValue), [7])
     }
 
     /**

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -12,8 +12,8 @@ import ReSwift
 struct TestAppState {
     var testValue: Int?
 
-    init() {
-        testValue = nil
+    init(testValue: Int? = nil) {
+        self.testValue = testValue
     }
 }
 


### PR DESCRIPTION
I noticed that the test for initial state dispatching to subscribers contained a state change via `SetValueAction`.

So the test didn't actually assert what it said.

I split this into 3 tests: one for simple state change, two for initial state dispatching.

This is such a weird oversight that I wonder if I interpreted the tests wrong, though.