### PR TITLE
Replaced open func subscribe<SelectedState: Equatable, S: StoreSubscr…

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **API Changes:**
 
 **Other:**
+- Replaced open func subscribe<SelectedState: Equatable, S: StoreSubscriber> with public func subscribe<SelectedState: Equatable, S: StoreSubscriber> and open func subscribe<S: StoreSubscriber>(_ subscriber: S) with public func subscribe<S: StoreSubscriber>(_ subscriber: S) since non-'@objc' instance method in extensions cannot be overridden, should use 'public' instead (#491) - @maksimgromov
 - Add tests to clarify initial state dispatch (#485) - @DivineDominion
 
 # 6.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **API Changes:**
 
 **Other:**
-- Replaced open func subscribe<SelectedState: Equatable, S: StoreSubscriber> with public func subscribe<SelectedState: Equatable, S: StoreSubscriber> and open func subscribe<S: StoreSubscriber>(_ subscriber: S) with public func subscribe<S: StoreSubscriber>(_ subscriber: S) since non-'@objc' instance method in extensions cannot be overridden, should use 'public' instead (#491) - @maksimgromov
+- Replaced `open func` with `public func` in extensions to `Store` because they cannot be overridden anyway (#491) - @maksimgromov
 - Add tests to clarify initial state dispatch (#485) - @DivineDominion
 
 # 6.1.0

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -217,7 +217,7 @@ open class Store<State>: StoreType {
 // MARK: Skip Repeats for Equatable States
 
 extension Store {
-    open func subscribe<SelectedState: Equatable, S: StoreSubscriber>(
+    public func subscribe<SelectedState: Equatable, S: StoreSubscriber>(
         _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?
         ) where S.StoreSubscriberStateType == SelectedState
     {
@@ -233,7 +233,7 @@ extension Store {
 }
 
 extension Store where State: Equatable {
-    open func subscribe<S: StoreSubscriber>(_ subscriber: S)
+	public func subscribe<S: StoreSubscriber>(_ subscriber: S)
         where S.StoreSubscriberStateType == State {
             guard subscriptionsAutomaticallySkipRepeats else {
                 subscribe(subscriber, transform: nil)


### PR DESCRIPTION
…iber> with public func subscribe<SelectedState: Equatable, S: StoreSubscriber> and open func subscribe<S: StoreSubscriber>(_ subscriber: S) with public func subscribe<S: StoreSubscriber>(_ subscriber: S) as required.