### PR TITLE
New Subscribe Methods Using AnySubscriber as an Arg

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -248,7 +248,6 @@ extension Store where State: Equatable {
 extension Store {
    public func subscribeAny<S: AnyStoreSubscriber, SelectedState: Equatable>(
     _ subscriber: S, keyPath: WritableKeyPath<State, SelectedState>, skipFirstState: Bool = false) {
-        
         // Create a subscription for the new subscriber.
         let originalSubscription = Subscription<State>()
 
@@ -269,10 +268,8 @@ extension Store {
     
     public func subscribeAny<S: AnyStoreSubscriber, SelectedState: Equatable>(
         _ subscriber: S, transform: ((Subscription<State>) -> Subscription<SelectedState>)?) {
-            
          // Create a subscription for the new subscriber.
          let originalSubscription = Subscription<State>()
-         
          // Call the optional transformation closure. This allows callers to modify
          // the subscription, e.g. in order to subselect parts of the store's state.
          var transformedSubscription = transform?(originalSubscription)
@@ -288,7 +285,6 @@ extension Store {
     fileprivate func _subscribeAny<SelectedState, S: AnyStoreSubscriber>(
         _ subscriber: S, originalSubscription: Subscription<State>,
         transformedSubscription: Subscription<SelectedState>?) {
-            
         let subscriptionBox = self.subscriptionBox(
             originalSubscription: originalSubscription,
             transformedSubscription: transformedSubscription,

--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -145,6 +145,20 @@ public class Subscription<State> {
             }
         }
     }
+    
+    /// Allows skipping when oldState is nil
+    public func skipFirstState() -> Subscription<State> {
+        Subscription<State> { sink in
+            self.observer = { oldState, newState in
+                switch (oldState, newState) {
+                case (.none, _):
+                    return
+                default:
+                    sink(oldState, newState)
+                }
+            }
+        }
+    }
 
     /// The closure called with changes from the store.
     /// This closure can be written to for use in extensions to Subscription similar to `skipRepeats`


### PR DESCRIPTION
I've never liked all the boilerplate code for multi-Subscriptions--ie. subscriptions instantiated in a viewController that implement StoreSubscriber. I've managed to code a solution that would allow devs to use a shortcut notation using a keyPath like so:

```
handleSubscription( \.deviceState.applicationState ) { [weak self] state in
    if let error = state as? ApplicationState {
          // do work here
     }
   }
```

versus the standard way:

```
private lazy var applicationStateSubscriber
     = AnonymousStoreSubscriber<DeviceState> { [weak self] state in
       self?.newApplicationState(in: state)
     }
   
   store.subscribe(applicationStateSubscriber) { subscription in
     subscription
       .select { $0.deviceState }
       .skip { $0.applicationState == $1.applicationState }
   }
```
   
By implementing an `AnySubscriber` like this:
   
```
public class ManySubscriber: AnyStoreSubscriber {

    public init(onNewState: @escaping (Any) -> Void) {
        self.onNewState = onNewState
    }

    public func _newState(state: Any) {
        self.onNewState(state)
    }

    public var onNewState: (Any) -> Void
}
```

We can add this `ManySubscriber` to a base viewController for managing subscriptions :

  ```
   var subscribers = [ManySubscriber]()

    func handleSubscription<SelectedState: Equatable>(_ keyPath: WritableKeyPath<AppState, SelectedState>,
        onNewState: @escaping (Any) -> Void ) {

        let subscriber = ManySubscriber { _ in }
        subscribers.append(subscriber)
        subscriber.onNewState = onNewState
        store.subscribeAny(subscriber, keyPath: keyPath)
    }

    deinit {
        subscribers.forEach { store.unsubscribe($0) }
    }
```

I've intentionally called the new method `subscribeAny()` to avoid confusion with the original `subscribe()` method. 

I am aware that this approach means the Value passed in the KeyPath will not be **_**typed**_**.
   


**UPDATE:**  I've added a second overloaded `subscribeAny()` call which takes 2 closures as args--a subscription and newState handler. It is invoked liked so:

```
handleSubscription( { subscription in
          subscription
              .select { $0.state1 }
              .skip { $0.counter1 == $1.counter1 }
      }) { [weak self] state in
          if let state = state as? State1 {
              self?.counterLabel.text = "\(state.counter1)"
          }
      }
```
      
In this call we conveniently keep together in one place WHAT WE ARE SUBSCRIBING TO and HOW WE HANDLE IT.
   